### PR TITLE
chore(nuvai-mkl): remove macOS x86_64 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nuvai-mkl
 
-A modern Rust wrapper over **Intel oneMKL 2026.1.0** on x86_64, and over
+A modern Rust wrapper over **Intel oneMKL 2026.1.0** on x86_64 Linux/Windows, and over
 Apple Silicon-native replacements (Accelerate / `rand`) on `aarch64-apple-darwin`.
 
 `nuvai-mkl` is the successor to the abandoned [`intel-mkl-src`](https://crates.io/crates/intel-mkl-src)
@@ -29,11 +29,11 @@ crates/
 
 ## Domain coverage
 
-`nuvai-mkl` targets the full oneMKL surface. On x86_64 every domain runs on
+`nuvai-mkl` targets the full oneMKL surface. On x86_64 Linux/Windows every domain runs on
 Intel oneMKL; on Apple Silicon each domain maps to a native backend behind the
 same typed API (ADR-0003).
 
-| MKL domain | x86_64 (Intel MKL) | aarch64-apple-darwin backend |
+| MKL domain | x86_64 Linux/Windows (Intel MKL) | aarch64-apple-darwin backend |
 |---|---|---|
 | **BLAS** | `cblas_*` / `?gemm`, `?gemv`, `?dot`, `?axpy` | Accelerate **vecLib** (`cblas_*`, symbol-aliased) or OpenBLAS |
 | **LAPACK** | `LAPACKE_*` (`?gesv`, `?getrf`, `?syev`, …) | Accelerate Fortran `_` entry points (`?gesv_`, …) + RowMajor shim, or OpenBLAS |
@@ -46,7 +46,7 @@ same typed API (ADR-0003).
 
 Selection is **explicit, never silent** (ADR-0003 decision 2):
 
-- On `x86_64` targets the backend is always Intel oneMKL; no feature changes that.
+- On `x86_64` Linux/Windows targets the backend is always Intel oneMKL; no feature changes that.
 - On `aarch64-apple-darwin` the non-MKL path is mandatory (`cfg(target_arch = "aarch64")`); the *choice* of backend is a Cargo feature on `nuvai-mkl`:
 
 | Feature | Default? | Effect on aarch64 |
@@ -64,7 +64,7 @@ Selection is **explicit, never silent** (ADR-0003 decision 2):
 |---|---|---|
 | `x86_64-unknown-linux-gnu` | Intel oneMKL (download conda-forge or system oneAPI) | ✅ |
 | `x86_64-pc-windows-msvc` | Intel oneMKL (download conda-forge or system oneAPI) | ✅ |
-| `x86_64-apple-darwin` | Intel oneMKL (system oneAPI) | ✅ |
+| `x86_64-apple-darwin` | — | ❌ unsupported (Intel ended macOS oneMKL after 2023.2.0) |
 | `aarch64-apple-darwin` (Apple Silicon) | Accelerate + `rand` (`accelerate` feature, default) | ✅ |
 | `aarch64-unknown-linux-gnu` | `openblas` feature (planned) | 🚧 planned |
 

--- a/crates/nuvai-mkl-src/Cargo.toml
+++ b/crates/nuvai-mkl-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nuvai-mkl-src"
-description = "Acquire and link Intel oneMKL 2026.1.0 — system-detect (MKLROOT/oneAPI) or download from conda-forge/NuGet"
+description = "Acquire and link Intel oneMKL 2026.1.0 — system-detect (MKLROOT/oneAPI) or download from conda-forge"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/nuvai-mkl-src/build.rs
+++ b/crates/nuvai-mkl-src/build.rs
@@ -38,7 +38,7 @@ fn main() {
     }
 }
 
-/// Emit the Intel oneMKL linker directives (x86_64 Linux/Windows/macOS).
+/// Emit the Intel oneMKL linker directives (x86_64 Linux/Windows).
 fn emit_intel_mkl() {
     let info = locate();
 
@@ -50,11 +50,6 @@ fn emit_intel_mkl() {
         println!("cargo:rustc-link-lib=dylib=dl");
         println!("cargo:rustc-link-lib=dylib=pthread");
         println!("cargo:rustc-link-lib=dylib=m");
-        println!("cargo:rustc-link-arg=-Wl,-rpath,{}", info.lib_dir.display());
-    }
-    #[cfg(target_os = "macos")]
-    {
-        println!("cargo:rustc-link-lib=dylib=mkl_rt");
         println!("cargo:rustc-link-arg=-Wl,-rpath,{}", info.lib_dir.display());
     }
     #[cfg(target_os = "windows")]

--- a/crates/nuvai-mkl-src/src/acquire.rs
+++ b/crates/nuvai-mkl-src/src/acquire.rs
@@ -108,15 +108,12 @@ fn download_mkl() -> MklInfo {
     let pkg_dir = cache_dir().join(format!("mkl-{MKL_VERSION}"));
 
     let ((mkl_file, mkl_sha), (include_file, include_sha)) =
-        match (cfg!(target_os = "linux"), cfg!(target_os = "windows"), cfg!(target_os = "macos")) {
-            (true, _, _) => ((LINUX_MKL, LINUX_MKL_SHA256), (LINUX_INCLUDE, LINUX_INCLUDE_SHA256)),
-            (_, true, _) => ((WIN_MKL, WIN_MKL_SHA256), (WIN_INCLUDE, WIN_INCLUDE_SHA256)),
-            (_, _, true) => panic!(
-                "macOS NuGet acquisition is not yet wired; install oneAPI and set MKLROOT."
-            ),
+        match (cfg!(target_os = "linux"), cfg!(target_os = "windows")) {
+            (true, _) => ((LINUX_MKL, LINUX_MKL_SHA256), (LINUX_INCLUDE, LINUX_INCLUDE_SHA256)),
+            (_, true) => ((WIN_MKL, WIN_MKL_SHA256), (WIN_INCLUDE, WIN_INCLUDE_SHA256)),
             _ => panic!(
                 "unsupported target for Intel oneMKL {MKL_VERSION}: MKL is x86_64 \
-                 Linux/Windows/macOS only. On aarch64 use the `accelerate`/`openblas` fallback."
+                 Linux/Windows only. On aarch64 use the `accelerate`/`openblas` fallback."
             ),
         };
 

--- a/crates/nuvai-mkl-src/src/backend.rs
+++ b/crates/nuvai-mkl-src/src/backend.rs
@@ -1,6 +1,6 @@
 // Backend selection for `nuvai-mkl-src`.
 //
-// This crate links Intel oneMKL on x86_64 (Linux/Windows/macOS) and falls back
+// This crate links Intel oneMKL on x86_64 Linux/Windows and falls back
 // to Accelerate or OpenBLAS on `aarch64-apple-darwin`, where Intel ships no
 // MKL. The selection is *explicit* — never silent:
 //
@@ -27,10 +27,21 @@ compile_error!(
      enable `accelerate` (default) or `openblas`"
 );
 
+// `x86_64-apple-darwin` is unsupported: Intel ended oneMKL for macOS after the
+// 2023.2.0 release (well short of the 2026.1.0 this crate links), so no
+// supported acquisition path exists. Reject at compile time rather than
+// half-linking against a stale manual oneAPI install.
+#[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
+compile_error!(
+    "nuvai-mkl-src: x86_64-apple-darwin is not supported — Intel ships no 2026.x \
+     oneMKL for macOS (last macOS build: 2023.2.0). Use aarch64-apple-darwin \
+     (Apple Silicon, Accelerate/OpenBLAS) or an x86_64 Linux/Windows target."
+);
+
 /// The link backend selected for the current build.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Backend {
-    /// Intel oneMKL (`mkl_rt`) — the x86_64 Linux/Windows/macOS path.
+    /// Intel oneMKL (`mkl_rt`) — the x86_64 Linux/Windows path.
     IntelMkl,
     /// Apple's Accelerate framework (`-framework Accelerate`) — the default
     /// `aarch64-apple-darwin` fallback.

--- a/crates/nuvai-mkl-src/src/lib.rs
+++ b/crates/nuvai-mkl-src/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Acquires and links a numerical backend into your crate.
 //!
-//! On x86_64 this crate locates Intel oneMKL **2026.1.0** — the system oneAPI
+//! On x86_64 Linux/Windows this crate locates Intel oneMKL **2026.1.0** — the system oneAPI
 //! install via `MKLROOT`, or a conda-forge download (Linux, Windows) into a
 //! shared cache — and emits the linker directives.
 //!
@@ -21,7 +21,7 @@
 //! |---|---|
 //! | `x86_64-unknown-linux-gnu` | Intel oneMKL — download (conda-forge) or system |
 //! | `x86_64-pc-windows-msvc` | Intel oneMKL — download (conda-forge) or system |
-//! | `x86_64-apple-darwin` | Intel oneMKL — system only (NuGet wiring pending) |
+//! | `x86_64-apple-darwin` | unsupported (Intel ended macOS oneMKL after 2023.2.0) |
 //! | `aarch64-apple-darwin` (Apple Silicon) | Accelerate (default) or OpenBLAS |
 //! | `aarch64-unknown-linux-gnu` | not yet wired (plan: OpenBLAS) |
 

--- a/crates/nuvai-mkl-sys/Cargo.toml
+++ b/crates/nuvai-mkl-sys/Cargo.toml
@@ -28,6 +28,6 @@ nuvai-mkl-src = { workspace = true }
 nuvai-mkl-src = { workspace = true }
 
 # bindgen is only needed where oneMKL headers exist; on aarch64-apple-darwin
-# the FFI surface is hand-written and bindgen would be a needless build cost.
-[target.'cfg(not(all(target_os = "macos", target_arch = "aarch64")))'.build-dependencies]
+# the FFI surface is hand-written and x86_64-apple-darwin is unsupported.
+[target.'cfg(not(target_os = "macos"))'.build-dependencies]
 bindgen = "0.71"

--- a/crates/nuvai-mkl-sys/build.rs
+++ b/crates/nuvai-mkl-sys/build.rs
@@ -5,9 +5,9 @@
 //! skipped entirely and the crate compiles the hand-written Accelerate FFI
 //! surface in `src/aarch64.rs` instead. The Intel x86_64 path is unchanged.
 
-#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+#[cfg(not(target_os = "macos"))]
 use std::env;
-#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+#[cfg(not(target_os = "macos"))]
 use std::path::PathBuf;
 
 fn main() {
@@ -27,7 +27,7 @@ fn main() {
         println!("cargo:metadata=BACKEND={}", nuvai_mkl_src::backend_tag(backend));
     }
 
-    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[cfg(not(target_os = "macos"))]
     {
         let info = nuvai_mkl_src::locate();
         eprintln!(

--- a/crates/nuvai-mkl-sys/src/lib.rs
+++ b/crates/nuvai-mkl-sys/src/lib.rs
@@ -32,5 +32,5 @@ mod aarch64;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 pub use aarch64::*;
 
-#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+#[cfg(not(target_os = "macos"))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/crates/nuvai-mkl/build.rs
+++ b/crates/nuvai-mkl/build.rs
@@ -21,7 +21,7 @@ fn main() {
         println!("cargo:metadata=BACKEND={}", nuvai_mkl_src::backend_tag(backend));
     }
 
-    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[cfg(not(target_os = "macos"))]
     {
         let info = nuvai_mkl_src::locate();
         let lib_dir = info.lib_dir.display();
@@ -31,10 +31,6 @@ fn main() {
             // conda-forge's `libmkl_core.so.3` references `log`/`exp`/`sin`/… but
             // does not declare a DT_NEEDED on libm, so keep libm in the final link.
             println!("cargo:rustc-link-arg=-Wl,--no-as-needed,-lm,--as-needed");
-            println!("cargo:rustc-link-arg=-Wl,-rpath,{lib_dir}");
-        }
-        #[cfg(target_os = "macos")]
-        {
             println!("cargo:rustc-link-arg=-Wl,-rpath,{lib_dir}");
         }
     }


### PR DESCRIPTION
## Summary

Remove `x86_64-apple-darwin` support. Intel ended oneMKL for macOS after the 2023.2.0 release, so no 2026.1.0 build exists for that target — the NuGet wiring planned in #8 cannot reach the version this crate links.

## Changes

- `backend.rs`: `compile_error!` on `x86_64-apple-darwin` — a single gate that fails the whole workspace at build time with a clear pointer to supported targets.
- `acquire.rs`: dropped the macOS NuGet panic arm (Linux/Windows only now).
- Narrowed `not(macos && aarch64)` → `not(macos)` in `-sys`/`-mkl`; removed the macOS `mkl_rt`/rpath linker branches.
- Docs + README updated to mark the target unsupported.

## Verification

- `cargo check --workspace` passes on `aarch64-apple-darwin` (Apple Silicon unaffected).
- `cargo check --target x86_64-apple-darwin -p nuvai-mkl-src` fails with the intended `compile_error!`.

Refs #6, #8