### PR TITLE
fix(nuvai-mkl-sys): short-circuit build.rs on DOCS_RS

### DIFF
--- a/crates/nuvai-mkl-src/Cargo.toml
+++ b/crates/nuvai-mkl-src/Cargo.toml
@@ -35,3 +35,9 @@ zip = "0.6"
 zstd = "0.13"
 tar = "0.4"
 sha2 = "0.10"
+
+# docs.rs has no network and no MKL; build with no features so the
+# docs.rs build never pulls acquisition/linking (build.rs also short-circuits on DOCS_RS).
+[package.metadata.docs.rs]
+all-features = false
+default-features = false

--- a/crates/nuvai-mkl-src/build.rs
+++ b/crates/nuvai-mkl-src/build.rs
@@ -87,6 +87,10 @@ fn emit_intel_mkl(target_os: &str) {
             println!("cargo:rustc-link-lib=dylib=dl");
             println!("cargo:rustc-link-lib=dylib=pthread");
             println!("cargo:rustc-link-lib=dylib=m");
+            if let Some(omp) = &info.omp_lib_dir {
+                println!("cargo:rustc-link-search=native={}", omp.display());
+                println!("cargo:rustc-link-lib=dylib=iomp5");
+            }
             println!("cargo:rustc-link-arg=-Wl,-rpath,{}", info.lib_dir.display());
         }
         "windows" => {

--- a/crates/nuvai-mkl-src/src/acquire.rs
+++ b/crates/nuvai-mkl-src/src/acquire.rs
@@ -59,6 +59,17 @@ const WIN_LLVM_OPENMP_SHA256: &str =
     "50c02902bb516eeb56680358f052be38b5bf74b40e78ea4b2a675e84957e7307";
 #[cfg(not(target_arch = "aarch64"))]
 const WIN_TBB_SHA256: &str = "e55a2f1324f0fc8916ab8d590a3944ba1af62de727bb66e3019cf2744d26e679";
+// The linux-64 `mkl` package's `libmkl_intel_thread.so.3` leaves its OpenMP
+// `omp_*` symbols undefined (no DT_NEEDED on the runtime), exactly as the
+// win-64 build does — so the OpenMP runtime must be fetched and linked
+// explicitly. conda-forge ships it as `llvm-openmp` on both platforms (the
+// `intel-openmp` package is win-64 only); on linux-64 it provides
+// `libiomp5.so` (a symlink to `libomp.so`).
+#[cfg(not(target_arch = "aarch64"))]
+const LINUX_LLVM_OPENMP: &str = "llvm-openmp-22.1.8-h4922eb0_0.conda";
+#[cfg(not(target_arch = "aarch64"))]
+const LINUX_LLVM_OPENMP_SHA256: &str =
+    "a37aba21b85800af1e7c5b04ba76abab96b6e591eedf99dc6e4df83b0fefd7a5";
 
 /// Resolved location of an MKL install.
 #[derive(Debug, Clone)]
@@ -67,6 +78,12 @@ pub struct MklInfo {
     pub include_dir: PathBuf,
     /// Directory containing the MKL libraries.
     pub lib_dir: PathBuf,
+    /// Directory containing the OpenMP runtime (`libiomp5.so`, a symlink to
+    /// `libomp.so`) that `libmkl_intel_thread.so.3` needs at load time. Linux
+    /// conda acquisition only; `None` on Windows (the runtime DLL is surfaced
+    /// via [`dll_dirs`]) and on a system oneAPI install (its OpenMP runtime
+    /// ships beside MKL and the loader finds it on the standard path).
+    pub omp_lib_dir: Option<PathBuf>,
     /// Directories containing the MKL runtime DLLs (Windows only; empty on
     /// platforms where the runtime loader finds them via rpath / system search).
     ///
@@ -157,7 +174,7 @@ fn system_mkl() -> Option<MklInfo> {
     } else {
         Vec::new()
     };
-    Some(MklInfo { include_dir, lib_dir, dll_dirs })
+    Some(MklInfo { include_dir, lib_dir, omp_lib_dir: None, dll_dirs })
 }
 
 /// Download + extract MKL into the shared cache, returning its paths.
@@ -175,7 +192,7 @@ fn download_mkl() -> MklInfo {
             (LINUX_MKL, LINUX_MKL_SHA256),
             (LINUX_INCLUDE, LINUX_INCLUDE_SHA256),
             None,
-            &[][..],
+            &[(LINUX_LLVM_OPENMP, LINUX_LLVM_OPENMP_SHA256)][..],
         ),
         // The win-64 `mkl` package is 26 DLLs with no `.lib` — import libs ship
         // in a third package, `mkl-devel`. Its threading layers also need the
@@ -208,14 +225,22 @@ fn download_mkl() -> MklInfo {
         MklInfo {
             include_dir: include_root.join("Library").join("include"),
             lib_dir: devel_root.join("Library").join("lib"),
+            omp_lib_dir: None,
             dll_dirs,
         }
     } else {
         // Linux conda packages lay out headers under `include/` and libs under
         // `lib/`; the runtime loader finds the shared objects via rpath.
+        let mut omp_lib_dir = None;
+        for (file, sha) in runtime {
+            // The runtime entries are OpenMP runtime packages (`llvm-openmp`)
+            // whose `lib/` holds `libiomp5.so` (a symlink to `libomp.so`).
+            omp_lib_dir = Some(fetch_and_extract_conda(file, sha, &pkg_dir).join("lib"));
+        }
         MklInfo {
             include_dir: include_root.join("include"),
             lib_dir: mkl_root.join("lib"),
+            omp_lib_dir,
             dll_dirs: Vec::new(),
         }
     }

--- a/crates/nuvai-mkl-sys/Cargo.toml
+++ b/crates/nuvai-mkl-sys/Cargo.toml
@@ -32,3 +32,9 @@ nuvai-mkl-src = { workspace = true }
 # hand-written and x86_64-apple-darwin is unsupported.
 [target.'cfg(all(not(target_os = "macos"), not(target_arch = "aarch64")))'.build-dependencies]
 bindgen = "0.71"
+
+# docs.rs has no network and no MKL; build with no features so the
+# docs.rs build never pulls acquisition/linking (build.rs also short-circuits on DOCS_RS).
+[package.metadata.docs.rs]
+all-features = false
+default-features = false

--- a/crates/nuvai-mkl-sys/build.rs
+++ b/crates/nuvai-mkl-sys/build.rs
@@ -18,6 +18,12 @@
 //! x86_64 host selects the hand-written OpenBLAS surface instead of running the
 //! Intel bindgen path (`nuvai_mkl_src::locate()` is unavailable on an aarch64
 //! host and would also acquire the wrong-architecture headers).
+//!
+//! # docs.rs
+//!
+//! The docs.rs build has no network and no MKL. docs.rs sets the `DOCS_RS`
+//! environment variable, so this script returns before `nuvai_mkl_src::locate()`
+//! / bindgen on every target — mirroring the guard in `nuvai-mkl-src/build.rs`.
 
 #![allow(unused_imports)] // `PathBuf` is used only on Intel host builds
 
@@ -27,9 +33,15 @@ use std::path::PathBuf;
 fn main() {
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-env-changed=MKLROOT");
+    println!("cargo:rerun-if-env-changed=DOCS_RS");
     println!("cargo:rerun-if-changed=src/aarch64.rs");
     println!("cargo:rerun-if-changed=src/linux_aarch64.rs");
     println!("cargo:rerun-if-changed=src/netlib_abi.rs");
+
+    // docs.rs has no network and no MKL; skip locate()/bindgen there.
+    if std::env::var("DOCS_RS").is_ok() {
+        return;
+    }
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS is set");
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH is set");

--- a/crates/nuvai-mkl/Cargo.toml
+++ b/crates/nuvai-mkl/Cargo.toml
@@ -37,3 +37,9 @@ rand_distr = "0.6.0"
 
 [build-dependencies]
 nuvai-mkl-src = { workspace = true }
+
+# docs.rs has no network and no MKL; build with no features so the
+# docs.rs build never pulls acquisition/linking (build.rs also short-circuits on DOCS_RS).
+[package.metadata.docs.rs]
+all-features = false
+default-features = false

--- a/crates/nuvai-mkl/build.rs
+++ b/crates/nuvai-mkl/build.rs
@@ -49,6 +49,12 @@ fn main() {
             println!("cargo:rustc-link-arg=-Wl,-rpath,{}", info.lib_dir.display());
             if let Some(omp) = &info.omp_lib_dir {
                 println!("cargo:rustc-link-arg=-Wl,-rpath,{}", omp.display());
+                // `libmkl_intel_thread.so.3` references `omp_*` symbols without
+                // a DT_NEEDED on the OpenMP runtime, so keep `libiomp5.so` in
+                // the final link the same way libm is kept (see above): the
+                // test/example objects never reference it directly, so plain
+                // `--as-needed` would drop it from DT_NEEDED.
+                println!("cargo:rustc-link-arg=-Wl,--no-as-needed,-liomp5,--as-needed");
             }
         }
         // Intel x86_64 Windows: no rpath; the loader resolves `mkl_rt.3.dll`

--- a/crates/nuvai-mkl/build.rs
+++ b/crates/nuvai-mkl/build.rs
@@ -47,6 +47,9 @@ fn main() {
             let info = nuvai_mkl_src::locate();
             println!("cargo:rustc-link-arg=-Wl,--no-as-needed,-lm,--as-needed");
             println!("cargo:rustc-link-arg=-Wl,-rpath,{}", info.lib_dir.display());
+            if let Some(omp) = &info.omp_lib_dir {
+                println!("cargo:rustc-link-arg=-Wl,-rpath,{}", omp.display());
+            }
         }
         // Intel x86_64 Windows: no rpath; the loader resolves `mkl_rt.3.dll`
         // (and `libiomp5md.dll` / `tbb12.dll`) at process start from PATH (or


### PR DESCRIPTION
## Summary

Adds docs.rs build support for all three crates (`nuvai-mkl-src`, `nuvai-mkl-sys`, `nuvai-mkl`). The docs.rs build has no network and no MKL.

### The fix

`crates/nuvai-mkl-sys/build.rs` was the one build script that did not short-circuit on `DOCS_RS` — it called `nuvai_mkl_src::locate()`/bindgen on every non-aarch64 build, which would attempt MKL acquisition under docs.rs. This PR:

1. Adds `cargo:rerun-if-env-changed=DOCS_RS` to the rerun block.
2. Returns early when `DOCS_RS` is set, **before** the target dispatch, so it short-circuits every arm (Intel `locate()`+bindgen AND the aarch64 hand-written arms) — mirroring the existing guards in `crates/nuvai-mkl-src/build.rs` and `crates/nuvai-mkl/build.rs`.
3. Documents the short-circuit in the build.rs module doc comment.
4. Adds `[package.metadata.docs.rs]` (`all-features = false`, `default-features = false`) to all three crate manifests, so the docs.rs build never sweeps in the `openblas` feature or the default `accelerate` feature.

### Verification

All gates green (exit 0):

- `DOCS_RS=1 cargo doc --workspace --no-deps` — build scripts re-run, no acquisition/linking output emitted
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy -p nuvai-mkl-src -p nuvai-mkl-sys -p nuvai-mkl -- -D warnings`
- grep guards: DOCS_RS short-circuit present in all three build scripts; `[package.metadata.docs.rs]` present in all three manifests; no untracked markers

Closes #10