### PR TITLE
perf: close PR #5 review gaps (PARDISO/VSL/FFT + unsafe lint hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
   aarch64-darwin:
     name: aarch64-apple-darwin (Accelerate)
     runs-on: macos-14-xlarge # public Apple Silicon runner (arm64)
+    env:
+      # The FFT backend uses vDSP's interleaved-complex DFT, which is
+      # `API_AVAILABLE(macos(12.0))` (task #13); pin the deployment target so
+      # the linker accepts those symbols without an availability warning.
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
     steps:
       - uses: actions/checkout@v4
 
@@ -47,6 +52,9 @@ jobs:
     env:
       # openblas is keg-only, so `-lopenblas` needs an explicit search path.
       RUSTFLAGS: "-L /opt/homebrew/opt/openblas/lib"
+      # Same as the Accelerate job: vDSP's interleaved-complex DFT (task #13)
+      # is macOS 12.0+, so pin the deployment target for the linker.
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Selection is **explicit, never silent** (ADR-0003 decision 2):
 | `x86_64-unknown-linux-gnu` | Intel oneMKL — conda-forge `mkl` + `mkl-include`, or system oneAPI (`MKLROOT`) | ✅ |
 | `x86_64-pc-windows-msvc` | Intel oneMKL — conda-forge `mkl` + `mkl-include` + `mkl-devel` + `llvm-openmp` + `tbb` (links `mkl_rt` → `mkl_rt.3.dll`; runtime DLLs `libiomp5md.dll`/`tbb12.dll` on `PATH`), or system oneAPI (`MKLROOT`) | ✅ |
 | `x86_64-apple-darwin` | — | ❌ unsupported (Intel ended macOS oneMKL after 2023.2.0) |
-| `aarch64-apple-darwin` (Apple Silicon) | Accelerate + `rand` (`accelerate` feature, default) | ✅ |
+| `aarch64-apple-darwin` (Apple Silicon, macOS 12.0+) | Accelerate + `rand` (`accelerate` feature, default) | ✅ |
 | `aarch64-unknown-linux-gnu` | OpenBLAS — system `libopenblas-dev` (BLAS/LAPACK only; FFT/VML/VSL/sparse return `ErrorKind::Unsupported`) | ✅ |
 
 On `x86_64-pc-windows-msvc` the Windows loader resolves the MKL runtime
@@ -87,6 +87,7 @@ not exist there).
 - Rust (built against **1.99 nightly**, edition 2024).
 - First build downloads ~140 MB of MKL into `~/.cache/nuvai-mkl/` (cached thereafter; on Windows the cache falls back to `%USERPROFILE%\.cache\nuvai-mkl` since `HOME` is often unset, and the acquisition also fetches `mkl-devel`, `llvm-openmp` and `tbb`).
 - `libclang` + `bindgen` for regenerating FFI bindings on Intel targets (LLVM on Windows, `libclang-dev` on Linux). The ARM64 aarch64 targets use a hand-written FFI surface and need no libclang.
+- On `aarch64-apple-darwin`, **macOS 12.0+** is required: the FFT backend uses vDSP's interleaved-complex DFT (`vDSP_DFT_Interleaved_*`), which is `API_AVAILABLE(macos(12.0))`.
 - On `aarch64-unknown-linux-gnu`, OpenBLAS is the sole backend: install `libopenblas-dev` (system default search path), or point `OPENBLAS_ROOT` at a conda/pip install — `nuvai-mkl-src` adds its `lib` dir to the propagated link-search path, and the workspace's own test/example binaries get the matching runtime rpath via `nuvai-mkl`'s build script (`cargo:rustc-link-arg` only applies to the emitting crate's own targets, so downstream crates linking a non-system OpenBLAS must set their own rpath).
 
 ## Usage

--- a/crates/nuvai-mkl-sys/src/aarch64.rs
+++ b/crates/nuvai-mkl-sys/src/aarch64.rs
@@ -51,6 +51,35 @@ pub type vDSP_DFT_Setup = *mut c_void;
 /// Opaque double-precision DFT setup (`struct vDSP_DFT_SetupStructD *`).
 pub type vDSP_DFT_SetupD = *mut c_void;
 
+/// Opaque interleaved-complex DFT setup (`struct vDSP_DFT_Interleaved_SetupStruct *`).
+pub type vDSP_DFT_Interleaved_Setup = *mut c_void;
+/// Opaque double-precision interleaved-complex DFT setup.
+pub type vDSP_DFT_Interleaved_SetupD = *mut c_void;
+
+/// Real-to-complex flag for the interleaved DFT (`vDSP_ENUM(bool,
+/// vDSP_DFT_RealtoComplex)`). Declared `c_int` for ABI uniformity with the
+/// other vDSP enum args; only `0`/`1` is ever passed, so the callee's `_Bool`
+/// read is correct.
+pub type vDSP_DFT_RealtoComplex = c_int;
+pub const vDSP_DFT_Interleaved_ComplextoComplex: vDSP_DFT_RealtoComplex = 0;
+pub const vDSP_DFT_Interleaved_RealtoComplex: vDSP_DFT_RealtoComplex = 1;
+
+/// Interleaved single-precision complex (layout-identical to `MKL_Complex8`).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DSPComplex {
+    pub real: f32,
+    pub imag: f32,
+}
+
+/// Interleaved double-precision complex (layout-identical to `MKL_Complex16`).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DSPDoubleComplex {
+    pub real: f64,
+    pub imag: f64,
+}
+
 // ---------------------------------------------------------------------------
 // vForce (note argument order: `(y, x, n)` — unlike MKL's `(n, src, dst)`)
 // ---------------------------------------------------------------------------
@@ -289,6 +318,35 @@ unsafe extern "C" {
     );
     pub fn vDSP_DFT_DestroySetup(setup: vDSP_DFT_Setup);
     pub fn vDSP_DFT_DestroySetupD(setup: vDSP_DFT_SetupD);
+
+    // --- vDSP DFT (interleaved complex, macOS 12.0+) ---
+    // Unlike the split family above, these transform an interleaved
+    // `DSP*Complex` buffer directly (no split/reinterleave copy). Availability
+    // is `API_AVAILABLE(macos(12.0), …)` — later than the split family's 10.7.
+    pub fn vDSP_DFT_Interleaved_CreateSetup(
+        previous: vDSP_DFT_Interleaved_Setup,
+        length: vDSP_Length,
+        direction: vDSP_DFT_Direction,
+        real_to_complex: vDSP_DFT_RealtoComplex,
+    ) -> vDSP_DFT_Interleaved_Setup;
+    pub fn vDSP_DFT_Interleaved_CreateSetupD(
+        previous: vDSP_DFT_Interleaved_SetupD,
+        length: vDSP_Length,
+        direction: vDSP_DFT_Direction,
+        real_to_complex: vDSP_DFT_RealtoComplex,
+    ) -> vDSP_DFT_Interleaved_SetupD;
+    pub fn vDSP_DFT_Interleaved_Execute(
+        setup: vDSP_DFT_Interleaved_Setup,
+        ir: *const DSPComplex,
+        or: *mut DSPComplex,
+    );
+    pub fn vDSP_DFT_Interleaved_ExecuteD(
+        setup: vDSP_DFT_Interleaved_SetupD,
+        ir: *const DSPDoubleComplex,
+        or: *mut DSPDoubleComplex,
+    );
+    pub fn vDSP_DFT_Interleaved_DestroySetup(setup: vDSP_DFT_Interleaved_Setup);
+    pub fn vDSP_DFT_Interleaved_DestroySetupD(setup: vDSP_DFT_Interleaved_SetupD);
 
     // --- vForce (vector math; `(y, x, n)` argument order) ---
     pub fn vvexpf(y: *mut f32, x: *const f32, n: *const c_int);

--- a/crates/nuvai-mkl-sys/src/aarch64.rs
+++ b/crates/nuvai-mkl-sys/src/aarch64.rs
@@ -57,10 +57,10 @@ pub type vDSP_DFT_Interleaved_Setup = *mut c_void;
 pub type vDSP_DFT_Interleaved_SetupD = *mut c_void;
 
 /// Real-to-complex flag for the interleaved DFT (`vDSP_ENUM(bool,
-/// vDSP_DFT_RealtoComplex)`). Declared `c_int` for ABI uniformity with the
-/// other vDSP enum args; only `0`/`1` is ever passed, so the callee's `_Bool`
-/// read is correct.
-pub type vDSP_DFT_RealtoComplex = c_int;
+/// vDSP_DFT_RealtoComplex)`). The C enum's underlying type is `_Bool` (1 byte),
+/// so it is declared `u8` — not `c_int` (4 bytes) — to match the callee's ABI
+/// register width on ARM64. Only `0`/`1` is ever passed.
+pub type vDSP_DFT_RealtoComplex = u8;
 pub const vDSP_DFT_Interleaved_ComplextoComplex: vDSP_DFT_RealtoComplex = 0;
 pub const vDSP_DFT_Interleaved_RealtoComplex: vDSP_DFT_RealtoComplex = 1;
 

--- a/crates/nuvai-mkl/build.rs
+++ b/crates/nuvai-mkl/build.rs
@@ -39,7 +39,17 @@ fn main() {
                 println!("cargo:rustc-link-arg=-Wl,-rpath,{root}/lib");
             }
         }
-        ("macos", "aarch64") => {}
+        ("macos", "aarch64") => {
+            // The Accelerate interleaved vDSP DFT (`vDSP_DFT_Interleaved_*`) used
+            // by the FFT backend is API_AVAILABLE(macos(12.0)); rustc defaults
+            // the aarch64-apple-darwin deployment target to 11.0, which would
+            // strong-link those symbols and abort at load time on macOS 10.15/11
+            // with "Symbol not found". Pin the minimum so nuvai-mkl's own
+            // test/example/bench binaries load only on macOS 12.0+. Downstream
+            // binaries must set MACOSX_DEPLOYMENT_TARGET=12.0 themselves — a
+            // library build script cannot force the final link's min OS.
+            println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=12.0");
+        }
         // Intel x86_64 Linux: keep libm in the final link (conda's
         // `libmkl_core.so.3` references `log`/`exp`/`sin`/… without a
         // DT_NEEDED) and add the runtime rpath to the conda MKL shared objects.

--- a/crates/nuvai-mkl/src/fft.rs
+++ b/crates/nuvai-mkl/src/fft.rs
@@ -29,16 +29,35 @@ type FftHandle = nuvai_mkl_sys::DFTI_DESCRIPTOR_HANDLE;
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 struct FftHandle {
-    /// Forward DFT setup (`vDSP_DFT_zop_CreateSetup`, direction = FORWARD).
-    forward: nuvai_mkl_sys::vDSP_DFT_Setup,
-    /// Inverse DFT setup (`vDSP_DFT_zop_CreateSetup`, direction = INVERSE).
-    inverse: nuvai_mkl_sys::vDSP_DFT_Setup,
+    /// Which vDSP DFT family backs this plan.
+    backend: FftBackend,
     /// True for the single-precision (f32) variants; selects the `D` vDSP API.
     single: bool,
-    /// Reused split-complex scratch (`re`/`im`) for single-precision transforms.
-    scratch32: RefCell<Option<(Vec<f32>, Vec<f32>)>>,
-    /// Reused split-complex scratch for double-precision transforms.
-    scratch64: RefCell<Option<(Vec<f64>, Vec<f64>)>>,
+}
+
+/// The vDSP DFT family backing an aarch64 [`FftHandle`]. Interleaved-complex is
+/// preferred — it transforms the caller's `MKL_Complex*` buffer directly (no
+/// split/reinterleave copy) — but it can only plan lengths `f·2^n` for
+/// `f ∈ {2, 3, 5, 9, 15, 25}` with `n >= 2` (minimum 8) on macOS 12.0+. The
+/// split-complex family is the fallback for the two lengths below that (2 and
+/// 4), which need a deinterleave → execute → reinterleave round-trip through
+/// scratch arrays.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+enum FftBackend {
+    /// Interleaved-complex DFT (`vDSP_DFT_Interleaved_*`, macOS 12.0+).
+    Interleaved {
+        forward: nuvai_mkl_sys::vDSP_DFT_Interleaved_Setup,
+        inverse: nuvai_mkl_sys::vDSP_DFT_Interleaved_Setup,
+    },
+    /// Split-complex DFT (`vDSP_DFT_zop_*`, macOS 10.7+).
+    Split {
+        forward: nuvai_mkl_sys::vDSP_DFT_Setup,
+        inverse: nuvai_mkl_sys::vDSP_DFT_Setup,
+        /// Reused split-complex scratch (`re`/`im`) for single-precision transforms.
+        scratch32: RefCell<Option<(Vec<f32>, Vec<f32>)>>,
+        /// Reused split-complex scratch for double-precision transforms.
+        scratch64: RefCell<Option<(Vec<f64>, Vec<f64>)>>,
+    },
 }
 
 /// Uninhabited-in-practice handle on `aarch64-unknown-linux-gnu`: no FFT
@@ -84,75 +103,20 @@ impl FftPlan {
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
             let length = len as nuvai_mkl_sys::vDSP_Length;
-            // SAFETY: `CreateSetup`/`CreateSetupD` take a `prev` setup (null
-            // here) and the positive `length` validated above, returning a new
-            // setup (or null on failure). Each returned handle is owned and
-            // released exactly once by `Drop`/the error path below.
-            let (forward, inverse) = unsafe {
-                let forward = if single {
-                    nuvai_mkl_sys::vDSP_DFT_zop_CreateSetup(
-                        std::ptr::null_mut(),
-                        length,
-                        nuvai_mkl_sys::vDSP_DFT_FORWARD,
-                    )
-                } else {
-                    nuvai_mkl_sys::vDSP_DFT_zop_CreateSetupD(
-                        std::ptr::null_mut(),
-                        length,
-                        nuvai_mkl_sys::vDSP_DFT_FORWARD,
-                    )
-                };
-                let inverse = if single {
-                    nuvai_mkl_sys::vDSP_DFT_zop_CreateSetup(
-                        std::ptr::null_mut(),
-                        length,
-                        nuvai_mkl_sys::vDSP_DFT_INVERSE,
-                    )
-                } else {
-                    nuvai_mkl_sys::vDSP_DFT_zop_CreateSetupD(
-                        std::ptr::null_mut(),
-                        length,
-                        nuvai_mkl_sys::vDSP_DFT_INVERSE,
-                    )
-                };
-                (forward, inverse)
-            };
-            if forward.is_null() || inverse.is_null() {
-                // Best-effort release of whatever half was allocated, using the
-                // precision-matched destroy routine (as Drop does) — a double
-                // setup released through the single-precision destroy leaks.
-                // SAFETY: `forward`/`inverse` are either null or a valid setup
-                // returned by the matching `CreateSetup`/`CreateSetupD` call
-                // above, and each non-null setup is destroyed exactly once.
-                unsafe {
-                    if single {
-                        if !forward.is_null() {
-                            nuvai_mkl_sys::vDSP_DFT_DestroySetup(forward);
-                        }
-                        if !inverse.is_null() {
-                            nuvai_mkl_sys::vDSP_DFT_DestroySetup(inverse);
-                        }
-                    } else {
-                        if !forward.is_null() {
-                            nuvai_mkl_sys::vDSP_DFT_DestroySetupD(forward);
-                        }
-                        if !inverse.is_null() {
-                            nuvai_mkl_sys::vDSP_DFT_DestroySetupD(inverse);
-                        }
-                    }
-                }
+            // Prefer the interleaved family (no split/reinterleave copy); fall
+            // back to split-complex for the lengths interleaved cannot plan
+            // (2 and 4). vDSP reports an unsupported length as a null setup, so
+            // probing the setup is the source of truth for the length predicate
+            // rather than re-deriving the `f·2^n` factorization here.
+            let backend = Self::create_interleaved(length, single)
+                .or_else(|| Self::create_split(length, single));
+            let Some(backend) = backend else {
                 return Err(Error::unsupported(format!(
-                    "FFT length {len} is not supported by vDSP (supported: powers of two, and f·2^n for f in {{3, 5, 15}} with n >= 3)"
+                    "FFT length {len} is not supported by vDSP (supported: 2, 4, and f·2^n for f in {{2, 3, 5, 9, 15, 25}} with n >= 2)"
                 )));
-            }
+            };
             Ok(Self {
-                handle: FftHandle {
-                    forward,
-                    inverse,
-                    single,
-                    scratch32: RefCell::new(None),
-                    scratch64: RefCell::new(None),
-                },
+                handle: FftHandle { backend, single },
                 len,
             })
         }
@@ -368,68 +332,273 @@ impl FftPlan {
 
 /// Accelerate (`aarch64-apple-darwin`) FFT backend.
 ///
-/// vDSP operates on *split* complex (separate real/imag arrays), so each call
-/// deinterleaves the caller's `MKL_Complex*` buffer into split scratch arrays,
-/// runs [`nuvai_mkl_sys::vDSP_DFT_Execute`] in place, and re-interleaves the
-/// result. vDSP's inverse DFT is unnormalized, so the `1/n` backward scale is
-/// applied explicitly to match the DFTI contract on Intel.
+/// The plan prefers vDSP's interleaved-complex DFT (macOS 12.0+), which
+/// transforms the caller's `MKL_Complex*` buffer directly (layout-identical to
+/// `DSP*Complex`) with no split/reinterleave copy. For the two lengths that
+/// family cannot plan (2 and 4) it falls back to the split-complex DFT, which
+/// deinterleaves into `re`/`im` scratch arrays, runs
+/// [`nuvai_mkl_sys::vDSP_DFT_Execute`], and re-interleaves. Both families'
+/// inverse DFTs are unnormalized, so the `1/n` backward scale is applied
+/// explicitly to match the DFTI contract on Intel.
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 impl FftPlan {
+    /// Try to plan the interleaved-complex family. Returns `None` when the
+    /// length is unsupported (vDSP returns a null setup), signalling `create`
+    /// to fall back to the split family.
+    fn create_interleaved(
+        length: nuvai_mkl_sys::vDSP_Length,
+        single: bool,
+    ) -> Option<FftBackend> {
+        let complextocomplex = nuvai_mkl_sys::vDSP_DFT_Interleaved_ComplextoComplex;
+        // SAFETY: `CreateSetup`/`CreateSetupD` take a null `prev` setup and the
+        // positive `length`, returning a new setup (or null on failure). Each
+        // returned non-null handle is owned and released exactly once below or
+        // by `Drop`.
+        let (forward, inverse) = unsafe {
+            let forward = if single {
+                nuvai_mkl_sys::vDSP_DFT_Interleaved_CreateSetup(
+                    std::ptr::null_mut(),
+                    length,
+                    nuvai_mkl_sys::vDSP_DFT_FORWARD,
+                    complextocomplex,
+                )
+            } else {
+                nuvai_mkl_sys::vDSP_DFT_Interleaved_CreateSetupD(
+                    std::ptr::null_mut(),
+                    length,
+                    nuvai_mkl_sys::vDSP_DFT_FORWARD,
+                    complextocomplex,
+                )
+            };
+            let inverse = if single {
+                nuvai_mkl_sys::vDSP_DFT_Interleaved_CreateSetup(
+                    std::ptr::null_mut(),
+                    length,
+                    nuvai_mkl_sys::vDSP_DFT_INVERSE,
+                    complextocomplex,
+                )
+            } else {
+                nuvai_mkl_sys::vDSP_DFT_Interleaved_CreateSetupD(
+                    std::ptr::null_mut(),
+                    length,
+                    nuvai_mkl_sys::vDSP_DFT_INVERSE,
+                    complextocomplex,
+                )
+            };
+            (forward, inverse)
+        };
+        if forward.is_null() || inverse.is_null() {
+            // Best-effort release of whatever half was allocated, using the
+            // precision-matched destroy routine (as Drop does) — a double setup
+            // released through the single-precision destroy leaks.
+            // SAFETY: each pointer is null or a valid setup from the matching
+            // `CreateSetup`/`CreateSetupD` call above, destroyed exactly once.
+            unsafe {
+                if single {
+                    if !forward.is_null() {
+                        nuvai_mkl_sys::vDSP_DFT_Interleaved_DestroySetup(forward);
+                    }
+                    if !inverse.is_null() {
+                        nuvai_mkl_sys::vDSP_DFT_Interleaved_DestroySetup(inverse);
+                    }
+                } else {
+                    if !forward.is_null() {
+                        nuvai_mkl_sys::vDSP_DFT_Interleaved_DestroySetupD(forward);
+                    }
+                    if !inverse.is_null() {
+                        nuvai_mkl_sys::vDSP_DFT_Interleaved_DestroySetupD(inverse);
+                    }
+                }
+            }
+            return None;
+        }
+        Some(FftBackend::Interleaved { forward, inverse })
+    }
+
+    /// Plan the split-complex family (fallback for lengths 2 and 4). Returns
+    /// `None` when the length is unsupported.
+    fn create_split(length: nuvai_mkl_sys::vDSP_Length, single: bool) -> Option<FftBackend> {
+        // SAFETY: `CreateSetup`/`CreateSetupD` take a null `prev` setup and the
+        // positive `length`, returning a new setup (or null on failure). Each
+        // returned non-null handle is owned and released exactly once below or
+        // by `Drop`.
+        let (forward, inverse) = unsafe {
+            let forward = if single {
+                nuvai_mkl_sys::vDSP_DFT_zop_CreateSetup(
+                    std::ptr::null_mut(),
+                    length,
+                    nuvai_mkl_sys::vDSP_DFT_FORWARD,
+                )
+            } else {
+                nuvai_mkl_sys::vDSP_DFT_zop_CreateSetupD(
+                    std::ptr::null_mut(),
+                    length,
+                    nuvai_mkl_sys::vDSP_DFT_FORWARD,
+                )
+            };
+            let inverse = if single {
+                nuvai_mkl_sys::vDSP_DFT_zop_CreateSetup(
+                    std::ptr::null_mut(),
+                    length,
+                    nuvai_mkl_sys::vDSP_DFT_INVERSE,
+                )
+            } else {
+                nuvai_mkl_sys::vDSP_DFT_zop_CreateSetupD(
+                    std::ptr::null_mut(),
+                    length,
+                    nuvai_mkl_sys::vDSP_DFT_INVERSE,
+                )
+            };
+            (forward, inverse)
+        };
+        if forward.is_null() || inverse.is_null() {
+            // SAFETY: as `create_interleaved` — null or valid, destroyed once.
+            unsafe {
+                if single {
+                    if !forward.is_null() {
+                        nuvai_mkl_sys::vDSP_DFT_DestroySetup(forward);
+                    }
+                    if !inverse.is_null() {
+                        nuvai_mkl_sys::vDSP_DFT_DestroySetup(inverse);
+                    }
+                } else {
+                    if !forward.is_null() {
+                        nuvai_mkl_sys::vDSP_DFT_DestroySetupD(forward);
+                    }
+                    if !inverse.is_null() {
+                        nuvai_mkl_sys::vDSP_DFT_DestroySetupD(inverse);
+                    }
+                }
+            }
+            return None;
+        }
+        Some(FftBackend::Split {
+            forward,
+            inverse,
+            scratch32: RefCell::new(None),
+            scratch64: RefCell::new(None),
+        })
+    }
+
     fn transform_c32(&self, input: &[MKL_Complex8], output: &mut [MKL_Complex8], inverse: bool) {
         let n = self.len;
-        let mut scratch = self.handle.scratch32.borrow_mut();
-        let (re, im) = scratch.get_or_insert_with(|| (vec![0.0f32; n], vec![0.0f32; n]));
-        for (i, x) in input.iter().enumerate() {
-            re[i] = x.real;
-            im[i] = x.imag;
-        }
-        let setup = if inverse { self.handle.inverse } else { self.handle.forward };
-        // SAFETY: `setup` is the non-null forward/inverse setup from `create`;
-        // `re`/`im` are length-`n` scratch arrays and `vDSP_DFT_Execute` reads
-        // the first `n` elements of each and writes them back in place
-        // (split-complex out-of-place transform), which `re`/`im` are sized for.
-        unsafe {
-            nuvai_mkl_sys::vDSP_DFT_Execute(
-                setup,
-                re.as_ptr(),
-                im.as_ptr(),
-                re.as_mut_ptr(),
-                im.as_mut_ptr(),
-            );
-        }
-        let scale = if inverse { 1.0 / n as f32 } else { 1.0f32 };
-        for (i, y) in output.iter_mut().enumerate() {
-            y.real = re[i] * scale;
-            y.imag = im[i] * scale;
+        match &self.handle.backend {
+            FftBackend::Interleaved { forward, inverse: inv } => {
+                let setup = if inverse { *inv } else { *forward };
+                // `DSPComplex` is layout-identical to `MKL_Complex8` (both
+                // `#[repr(C)] { real: f32, imag: f32 }`), so the caller's
+                // interleaved buffers cast directly — no deinterleave copy.
+                // SAFETY: `setup` is non-null; the pointers describe `n`
+                // interleaved complex elements each, and the out-of-place
+                // interleaved DFT reads `input` and writes the distinct `output`.
+                unsafe {
+                    nuvai_mkl_sys::vDSP_DFT_Interleaved_Execute(
+                        setup,
+                        input.as_ptr() as *const nuvai_mkl_sys::DSPComplex,
+                        output.as_mut_ptr() as *mut nuvai_mkl_sys::DSPComplex,
+                    );
+                }
+                // Forward needs no scale; inverse applies the `1/n`
+                // normalization to match the DFTI contract on Intel.
+                if inverse {
+                    let scale = 1.0 / n as f32;
+                    for y in output.iter_mut() {
+                        y.real *= scale;
+                        y.imag *= scale;
+                    }
+                }
+            }
+            FftBackend::Split {
+                forward,
+                inverse: inv,
+                scratch32,
+                ..
+            } => {
+                let mut scratch = scratch32.borrow_mut();
+                let (re, im) = scratch.get_or_insert_with(|| (vec![0.0f32; n], vec![0.0f32; n]));
+                for (i, x) in input.iter().enumerate() {
+                    re[i] = x.real;
+                    im[i] = x.imag;
+                }
+                let setup = if inverse { *inv } else { *forward };
+                // SAFETY: `setup` is the non-null split setup; `re`/`im` are
+                // length-`n` scratch arrays and `vDSP_DFT_Execute` reads and
+                // writes exactly the first `n` split-complex elements.
+                unsafe {
+                    nuvai_mkl_sys::vDSP_DFT_Execute(
+                        setup,
+                        re.as_ptr(),
+                        im.as_ptr(),
+                        re.as_mut_ptr(),
+                        im.as_mut_ptr(),
+                    );
+                }
+                let scale = if inverse { 1.0 / n as f32 } else { 1.0f32 };
+                for (i, y) in output.iter_mut().enumerate() {
+                    y.real = re[i] * scale;
+                    y.imag = im[i] * scale;
+                }
+            }
         }
     }
 
     fn transform_c64(&self, input: &[MKL_Complex16], output: &mut [MKL_Complex16], inverse: bool) {
         let n = self.len;
-        let mut scratch = self.handle.scratch64.borrow_mut();
-        let (re, im) = scratch.get_or_insert_with(|| (vec![0.0f64; n], vec![0.0f64; n]));
-        for (i, x) in input.iter().enumerate() {
-            re[i] = x.real;
-            im[i] = x.imag;
-        }
-        let setup = if inverse { self.handle.inverse } else { self.handle.forward };
-        // SAFETY: `setup` is the non-null forward/inverse setup from `create`;
-        // `re`/`im` are length-`n` scratch arrays and `vDSP_DFT_ExecuteD` reads
-        // and writes exactly the first `n` split-complex elements, which the
-        // scratch arrays are sized for.
-        unsafe {
-            nuvai_mkl_sys::vDSP_DFT_ExecuteD(
-                setup,
-                re.as_ptr(),
-                im.as_ptr(),
-                re.as_mut_ptr(),
-                im.as_mut_ptr(),
-            );
-        }
-        let scale = if inverse { 1.0 / n as f64 } else { 1.0f64 };
-        for (i, y) in output.iter_mut().enumerate() {
-            y.real = re[i] * scale;
-            y.imag = im[i] * scale;
+        match &self.handle.backend {
+            FftBackend::Interleaved { forward, inverse: inv } => {
+                let setup = if inverse { *inv } else { *forward };
+                // `DSPDoubleComplex` is layout-identical to `MKL_Complex16`
+                // (both `#[repr(C)] { real: f64, imag: f64 }`), so the caller's
+                // interleaved buffers cast directly — no deinterleave copy.
+                // SAFETY: `setup` is non-null; the pointers describe `n`
+                // interleaved complex elements each, and the out-of-place
+                // interleaved DFT reads `input` and writes the distinct `output`.
+                unsafe {
+                    nuvai_mkl_sys::vDSP_DFT_Interleaved_ExecuteD(
+                        setup,
+                        input.as_ptr() as *const nuvai_mkl_sys::DSPDoubleComplex,
+                        output.as_mut_ptr() as *mut nuvai_mkl_sys::DSPDoubleComplex,
+                    );
+                }
+                if inverse {
+                    let scale = 1.0 / n as f64;
+                    for y in output.iter_mut() {
+                        y.real *= scale;
+                        y.imag *= scale;
+                    }
+                }
+            }
+            FftBackend::Split {
+                forward,
+                inverse: inv,
+                scratch64,
+                ..
+            } => {
+                let mut scratch = scratch64.borrow_mut();
+                let (re, im) = scratch.get_or_insert_with(|| (vec![0.0f64; n], vec![0.0f64; n]));
+                for (i, x) in input.iter().enumerate() {
+                    re[i] = x.real;
+                    im[i] = x.imag;
+                }
+                let setup = if inverse { *inv } else { *forward };
+                // SAFETY: `setup` is the non-null split setup; `re`/`im` are
+                // length-`n` scratch arrays and `vDSP_DFT_ExecuteD` reads and
+                // writes exactly the first `n` split-complex elements.
+                unsafe {
+                    nuvai_mkl_sys::vDSP_DFT_ExecuteD(
+                        setup,
+                        re.as_ptr(),
+                        im.as_ptr(),
+                        re.as_mut_ptr(),
+                        im.as_mut_ptr(),
+                    );
+                }
+                let scale = if inverse { 1.0 / n as f64 } else { 1.0f64 };
+                for (i, y) in output.iter_mut().enumerate() {
+                    y.real = re[i] * scale;
+                    y.imag = im[i] * scale;
+                }
+            }
         }
     }
 }
@@ -443,16 +612,35 @@ impl Drop for FftPlan {
         }
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
-            // SAFETY: `self.handle.forward`/`inverse` are valid setups created
-            // non-null in `create`, and each is destroyed exactly once here via
-            // the precision-matched destroy routine.
-            unsafe {
-                if self.handle.single {
-                    nuvai_mkl_sys::vDSP_DFT_DestroySetup(self.handle.forward);
-                    nuvai_mkl_sys::vDSP_DFT_DestroySetup(self.handle.inverse);
-                } else {
-                    nuvai_mkl_sys::vDSP_DFT_DestroySetupD(self.handle.forward);
-                    nuvai_mkl_sys::vDSP_DFT_DestroySetupD(self.handle.inverse);
+            match &self.handle.backend {
+                FftBackend::Interleaved { forward, inverse } => {
+                    // SAFETY: `forward`/`inverse` are valid interleaved setups
+                    // created non-null in `create_interleaved`, and each is
+                    // destroyed exactly once here via the precision-matched
+                    // destroy routine.
+                    unsafe {
+                        if self.handle.single {
+                            nuvai_mkl_sys::vDSP_DFT_Interleaved_DestroySetup(*forward);
+                            nuvai_mkl_sys::vDSP_DFT_Interleaved_DestroySetup(*inverse);
+                        } else {
+                            nuvai_mkl_sys::vDSP_DFT_Interleaved_DestroySetupD(*forward);
+                            nuvai_mkl_sys::vDSP_DFT_Interleaved_DestroySetupD(*inverse);
+                        }
+                    }
+                }
+                FftBackend::Split { forward, inverse, .. } => {
+                    // SAFETY: `forward`/`inverse` are valid split setups created
+                    // non-null in `create_split`, and each is destroyed exactly
+                    // once here via the precision-matched destroy routine.
+                    unsafe {
+                        if self.handle.single {
+                            nuvai_mkl_sys::vDSP_DFT_DestroySetup(*forward);
+                            nuvai_mkl_sys::vDSP_DFT_DestroySetup(*inverse);
+                        } else {
+                            nuvai_mkl_sys::vDSP_DFT_DestroySetupD(*forward);
+                            nuvai_mkl_sys::vDSP_DFT_DestroySetupD(*inverse);
+                        }
+                    }
                 }
             }
         }

--- a/crates/nuvai-mkl/src/fft.rs
+++ b/crates/nuvai-mkl/src/fft.rs
@@ -103,16 +103,31 @@ impl FftPlan {
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
             let length = len as nuvai_mkl_sys::vDSP_Length;
-            // Prefer the interleaved family (no split/reinterleave copy); fall
-            // back to split-complex for the lengths interleaved cannot plan
-            // (2 and 4). vDSP reports an unsupported length as a null setup, so
-            // probing the setup is the source of truth for the length predicate
-            // rather than re-deriving the `f·2^n` factorization here.
-            let backend = Self::create_interleaved(length, single)
-                .or_else(|| Self::create_split(length, single));
-            let Some(backend) = backend else {
+            // Select the family deterministically from vDSP's documented length
+            // rules (vDSP_DFT.h) instead of treating a null setup as
+            // "unsupported": a null can also mean out-of-memory, which must not
+            // be misread as Unsupported nor silently downgraded to the slower
+            // split family. The interleaved family plans `f·2^n` for
+            // `f ∈ {2, 3, 5, 9, 15, 25}` with `n >= 2` (minimum 8); only
+            // lengths 2 and 4 fall back to the split family.
+            let backend = if interleaved_supports(len) {
+                Self::create_interleaved(length, single).ok_or_else(|| {
+                    Error::unsupported(format!(
+                        "FFT length {len} is supported by vDSP's interleaved DFT \
+                         but the setup could not be created (out of memory?)"
+                    ))
+                })?
+            } else if len == 2 || len == 4 {
+                Self::create_split(length, single).ok_or_else(|| {
+                    Error::unsupported(format!(
+                        "FFT length {len} is supported by vDSP's split DFT \
+                         but the setup could not be created (out of memory?)"
+                    ))
+                })?
+            } else {
                 return Err(Error::unsupported(format!(
-                    "FFT length {len} is not supported by vDSP (supported: 2, 4, and f·2^n for f in {{2, 3, 5, 9, 15, 25}} with n >= 2)"
+                    "FFT length {len} is not supported by vDSP (supported: 2, 4, \
+                     and f·2^n for f in {{2, 3, 5, 9, 15, 25}} with n >= 2)"
                 )));
             };
             Ok(Self {
@@ -340,6 +355,29 @@ impl FftPlan {
 /// [`nuvai_mkl_sys::vDSP_DFT_Execute`], and re-interleaves. Both families'
 /// inverse DFTs are unnormalized, so the `1/n` backward scale is applied
 /// explicitly to match the DFTI contract on Intel.
+///
+/// Whether `len` is planable by vDSP's interleaved-complex DFT: `len = f·2^n`
+/// for `f ∈ {2, 3, 5, 9, 15, 25}` and `n >= 2` (vDSP_DFT.h). Used to select the
+/// family deterministically so a null setup on a supported length is reported as
+/// a setup failure (out of memory) rather than misread as an unsupported length.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn interleaved_supports(len: usize) -> bool {
+    // Minimum interleaved length is f_min · 2^2 = 2 · 4 = 8.
+    if len < 8 {
+        return false;
+    }
+    // `len = f · 2^n` with `n >= 2` iff `len / f` is a power of two `>= 4`.
+    for f in [2usize, 3, 5, 9, 15, 25] {
+        if len.is_multiple_of(f) {
+            let m = len / f;
+            if m.is_power_of_two() && m >= 4 {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 impl FftPlan {
     /// Try to plan the interleaved-complex family. Returns `None` when the

--- a/crates/nuvai-mkl/src/lib.rs
+++ b/crates/nuvai-mkl/src/lib.rs
@@ -29,6 +29,15 @@
 //! [`ErrorKind::Unsupported`]: error::ErrorKind::Unsupported
 
 #![allow(clippy::too_many_arguments)]
+// Every `unsafe` block below carries a `// SAFETY:` rationale, and the wrapper
+// defines no `unsafe fn`, so these lints are clean today and deny regressions:
+// a new `unsafe` block without a written justification, or an un-scoped `unsafe`
+// operation creeping into a future `unsafe fn`, fails the build instead of
+// passing review unnoticed.
+#![deny(unsafe_op_in_unsafe_fn)]
+// `undocumented_unsafe_blocks` is a Clippy restriction lint (there is no
+// rustc-level equivalent yet), so it is namespaced accordingly.
+#![deny(clippy::undocumented_unsafe_blocks)]
 
 pub use nuvai_mkl_sys::MKL_VERSION;
 

--- a/crates/nuvai-mkl/src/pardiso.rs
+++ b/crates/nuvai-mkl/src/pardiso.rs
@@ -42,10 +42,13 @@ pub mod mtype {
 /// A PARDISO solver handle (double precision).
 ///
 /// On Intel targets this holds the PARDISO `pt`/`iparm` state. On Apple
-/// Silicon the Accelerate backend performs a self-contained factor+solve per
-/// call and keeps only the caller's `mtype`, so the 768-byte PARDISO state is
-/// cfg'd out. On `aarch64-unknown-linux-gnu` there is no PARDISO backend and
-/// the handle is inert (every `solve` returns [`ErrorKind::Unsupported`]).
+/// Silicon the Accelerate backend caches the QR factorization of the most
+/// recently solved matrix and reuses it when the matrix is unchanged, so only
+/// `mtype` and that cache are kept — the 768-byte PARDISO state is cfg'd out.
+/// Holding the raw-pointer factorization makes the Apple Silicon handle
+/// `!Send + !Sync`, matching the Intel backend. On
+/// `aarch64-unknown-linux-gnu` there is no PARDISO backend and the handle is
+/// inert (every `solve` returns [`ErrorKind::Unsupported`]).
 pub struct Pardiso {
     /// PARDISO internal state (Intel targets only).
     #[cfg(not(target_arch = "aarch64"))]
@@ -63,6 +66,28 @@ pub struct Pardiso {
     /// True once the analysis phase has run (Intel targets only).
     #[cfg(not(target_arch = "aarch64"))]
     analyzed: bool,
+    /// Cached QR factorization plus the CSR matrix that produced it (Apple
+    /// Silicon only). Reused across `solve` calls when the matrix is unchanged.
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    cached: Option<CachedFactor>,
+}
+
+/// A cached Accelerate QR factorization and the CSR matrix that produced it
+/// (Apple Silicon only).
+///
+/// [`SparseOpaqueFactorization_Double`] is `#[derive(Clone, Copy)]` for the
+/// struct-return ABI but owns heap memory through raw pointers, so it is stored
+/// here by value and moved — never `Copy`ed — to avoid aliasing the allocation
+/// and double-freeing it in `Drop`.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+struct CachedFactor {
+    /// The owned QR factorization (output of `_SparseFactorQR_Double`).
+    factor: nuvai_mkl_sys::SparseOpaqueFactorization_Double,
+    /// Copies of the caller's CSR input, compared with `==` to detect an
+    /// unchanged matrix and skip re-factoring.
+    ia: Vec<i32>,
+    ja: Vec<i32>,
+    a: Vec<f64>,
 }
 
 impl Pardiso {
@@ -87,11 +112,16 @@ impl Pardiso {
                 analyzed: false,
             }
         }
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
-            // On the aarch64 fallbacks the handle carries only `mtype`: the
-            // Accelerate backend factors+solves per call, and linux-aarch64 has
-            // no PARDISO backend (every `solve` returns Unsupported).
+            // The Accelerate backend starts with no cached factorization; it is
+            // populated on the first `solve` and reused for unchanged matrices.
+            Self { mtype, cached: None }
+        }
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        {
+            // linux-aarch64 has no PARDISO backend (every `solve` returns
+            // Unsupported), so the handle carries only `mtype`.
             Self { mtype }
         }
     }
@@ -219,8 +249,12 @@ impl Pardiso {
 ///
 /// Converts the caller's 1-based CSR input to a 0-based CSC
 /// `SparseMatrix_Double`, factors it with QR (`_SparseFactorQR_Double`), and
-/// solves with `_SparseSolveOpaque_Double`. The factorization is local and
-/// destroyed before returning; the matrix buffers stay alive for the call.
+/// solves with `_SparseSolveOpaque_Double`. The factorization is cached in
+/// `self.cached` and reused across `solve` calls when the CSR triple is
+/// unchanged; `b` is deliberately absent from the cache key, so a new
+/// right-hand side re-solves against the retained factor. Apple's factor
+/// routines copy the matrix into the factorization's own storage, so the local
+/// CSC buffers can be dropped after factoring.
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 impl Pardiso {
     fn solve_accelerate(&mut self, ia: &[i32], ja: &[i32], a: &[f64], b: &[f64]) -> Result<Vec<f64>> {
@@ -243,48 +277,75 @@ impl Pardiso {
             return Err(Error::invalid("PARDISO: bad ia/b lengths"));
         }
 
-        let (col_starts, row_indices, values) = csr_to_csc(n as usize, ia, ja, a, 1, false)?;
+        // Reuse the cached factorization when the matrix is unchanged (exact
+        // `==` on the CSR triple). `b` is deliberately absent from the key, so
+        // a new right-hand side re-solves against the retained factor.
+        let cache_hit = self
+            .cached
+            .as_ref()
+            .is_some_and(|c| c.ia.as_slice() == ia && c.ja.as_slice() == ja && c.a.as_slice() == a);
 
-        let matrix = nuvai_mkl_sys::SparseMatrix_Double {
-            structure: nuvai_mkl_sys::SparseMatrixStructure {
-                rowCount: n,
-                columnCount: n,
-                columnStarts: col_starts.as_ptr() as *mut c_long,
-                rowIndices: row_indices.as_ptr() as *mut i32,
-                attributes: nuvai_mkl_sys::SparseAttributes_t::ordinary(),
-                blockSize: 1,
-            },
-            data: values.as_ptr() as *mut f64,
-        };
+        if !cache_hit {
+            let (col_starts, row_indices, values) = csr_to_csc(n as usize, ia, ja, a, 1, false)?;
 
-        let sfoptions = default_symbolic_options();
-        let nfoptions = default_numeric_options();
+            let matrix = nuvai_mkl_sys::SparseMatrix_Double {
+                structure: nuvai_mkl_sys::SparseMatrixStructure {
+                    rowCount: n,
+                    columnCount: n,
+                    columnStarts: col_starts.as_ptr() as *mut c_long,
+                    rowIndices: row_indices.as_ptr() as *mut i32,
+                    attributes: nuvai_mkl_sys::SparseAttributes_t::ordinary(),
+                    blockSize: 1,
+                },
+                data: values.as_ptr() as *mut f64,
+            };
 
-        // SAFETY: `matrix` borrows the CSC arrays for the duration of the call;
-        // `SparseFactorizationQR` and the option structs are valid. The returned
-        // `SparseOpaqueFactorization_Double` is owned by value and freed once
-        // below.
-        let mut factor = unsafe {
-            nuvai_mkl_sys::_SparseFactorQR_Double(
-                nuvai_mkl_sys::SparseFactorizationQR,
-                &matrix,
-                &sfoptions,
-                &nfoptions,
-            )
-        };
-        if factor.status != nuvai_mkl_sys::SparseStatusOK {
-            let status = factor.status;
-            // SAFETY: `factor` is an owned, initialized factorization; released
-            // exactly once on the error path.
-            unsafe { nuvai_mkl_sys::_SparseDestroyOpaqueNumeric_Double(&mut factor) };
-            return Err(Error::mkl(status, "_SparseFactorQR_Double"));
+            let sfoptions = default_symbolic_options();
+            let nfoptions = default_numeric_options();
+
+            // SAFETY: `matrix` borrows the CSC arrays for the duration of the
+            // call; `SparseFactorizationQR` and the option structs are valid.
+            // The returned `SparseOpaqueFactorization_Double` is owned by value
+            // and stored in `self.cached` (released exactly once by `Drop`, or
+            // when a later, different matrix replaces it).
+            let mut factor = unsafe {
+                nuvai_mkl_sys::_SparseFactorQR_Double(
+                    nuvai_mkl_sys::SparseFactorizationQR,
+                    &matrix,
+                    &sfoptions,
+                    &nfoptions,
+                )
+            };
+            if factor.status != nuvai_mkl_sys::SparseStatusOK {
+                let status = factor.status;
+                // SAFETY: `factor` is an owned, initialized factorization;
+                // released exactly once on this error path (it was never cached).
+                unsafe { nuvai_mkl_sys::_SparseDestroyOpaqueNumeric_Double(&mut factor) };
+                return Err(Error::mkl(status, "_SparseFactorQR_Double"));
+            }
+
+            // Replace any previous cache entry: destroy the old factor exactly
+            // once, then store the fresh one together with copies of the CSR
+            // input it was factored from.
+            if let Some(old) = self.cached.take() {
+                let mut old_factor = old.factor;
+                // SAFETY: `old_factor` is an owned, initialized factorization
+                // that is no longer needed; moved out by value (never `Copy`ed)
+                // and destroyed exactly once here.
+                unsafe { nuvai_mkl_sys::_SparseDestroyOpaqueNumeric_Double(&mut old_factor) };
+            }
+            self.cached = Some(CachedFactor {
+                factor,
+                ia: ia.to_vec(),
+                ja: ja.to_vec(),
+                a: a.to_vec(),
+            });
         }
 
-        let result = solve_with_factor(&factor, n, b);
-        // SAFETY: `factor` is an owned, initialized factorization; released
-        // exactly once here after the solve.
-        unsafe { nuvai_mkl_sys::_SparseDestroyOpaqueNumeric_Double(&mut factor) };
-        let x = result?;
+        // `self.cached` is `Some` here: either this was a cache hit, or the
+        // branch above just populated it.
+        let factor = &self.cached.as_ref().expect("factorization cached").factor;
+        let x = solve_with_factor(factor, n, b)?;
 
         // QR factorization of a singular matrix still succeeds (R is simply
         // rank-deficient), so Accelerate reports no error and the solve returns a
@@ -515,11 +576,22 @@ pub(crate) fn default_numeric_options() -> nuvai_mkl_sys::SparseNumericFactorOpt
 
 impl Drop for Pardiso {
     fn drop(&mut self) {
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
-            // Nothing to release on the aarch64 fallbacks: the Accelerate
-            // backend creates and destroys its QR factorization inside
-            // `solve_accelerate`, and linux-aarch64 has no PARDISO backend.
+            // Release the cached QR factorization exactly once. It is moved out
+            // by value (`take` into a local) so the raw-pointer payload is
+            // never `Copy`ed/aliased.
+            if let Some(cached) = self.cached.take() {
+                let mut factor = cached.factor;
+                // SAFETY: `factor` is an owned, initialized factorization
+                // created by `_SparseFactorQR_Double`; destroyed exactly once.
+                unsafe { nuvai_mkl_sys::_SparseDestroyOpaqueNumeric_Double(&mut factor) };
+            }
+        }
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        {
+            // Nothing to release on aarch64-unknown-linux-gnu: no PARDISO
+            // backend, so a `Pardiso` can never hold a factorization there.
         }
         #[cfg(not(target_arch = "aarch64"))]
         {

--- a/crates/nuvai-mkl/src/pardiso.rs
+++ b/crates/nuvai-mkl/src/pardiso.rs
@@ -25,6 +25,7 @@ use std::os::raw::c_long;
     not(target_arch = "aarch64")
 ))]
 use std::ptr;
+use std::marker::PhantomData;
 
 use crate::error::{Error, Result};
 
@@ -45,10 +46,12 @@ pub mod mtype {
 /// Silicon the Accelerate backend caches the QR factorization of the most
 /// recently solved matrix and reuses it when the matrix is unchanged, so only
 /// `mtype` and that cache are kept — the 768-byte PARDISO state is cfg'd out.
-/// Holding the raw-pointer factorization makes the Apple Silicon handle
-/// `!Send + !Sync`, matching the Intel backend. On
-/// `aarch64-unknown-linux-gnu` there is no PARDISO backend and the handle is
-/// inert (every `solve` returns [`ErrorKind::Unsupported`]).
+/// The handle is `!Send + !Sync` on every backend (Intel's raw `pt` pointers,
+/// the Apple Silicon factor's raw pointers, and an explicit raw-pointer
+/// `PhantomData` on the inert linux-aarch64 handle), so share it behind a lock
+/// for cross-thread use. On `aarch64-unknown-linux-gnu` there is no PARDISO
+/// backend and the handle is inert (every `solve` returns
+/// [`ErrorKind::Unsupported`]).
 pub struct Pardiso {
     /// PARDISO internal state (Intel targets only).
     #[cfg(not(target_arch = "aarch64"))]
@@ -70,6 +73,12 @@ pub struct Pardiso {
     /// Silicon only). Reused across `solve` calls when the matrix is unchanged.
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     cached: Option<CachedFactor>,
+    /// Pin auto-trait parity across backends (see `vsl::Stream`'s identical
+    /// field). Intel's raw `pt` pointers and the Apple Silicon cached
+    /// factorization are `!Send + !Sync`; a raw-pointer `PhantomData` is also
+    /// `!Send + !Sync`, so the inert linux-aarch64 handle matches instead of
+    /// leaking `Send + Sync` on only one platform.
+    _not_send_sync: PhantomData<*const ()>,
 }
 
 /// A cached Accelerate QR factorization and the CSR matrix that produced it
@@ -110,19 +119,27 @@ impl Pardiso {
                 iparm,
                 n: 0,
                 analyzed: false,
+                _not_send_sync: PhantomData,
             }
         }
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
             // The Accelerate backend starts with no cached factorization; it is
             // populated on the first `solve` and reused for unchanged matrices.
-            Self { mtype, cached: None }
+            Self {
+                mtype,
+                cached: None,
+                _not_send_sync: PhantomData,
+            }
         }
         #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
         {
             // linux-aarch64 has no PARDISO backend (every `solve` returns
             // Unsupported), so the handle carries only `mtype`.
-            Self { mtype }
+            Self {
+                mtype,
+                _not_send_sync: PhantomData,
+            }
         }
     }
 
@@ -279,7 +296,10 @@ impl Pardiso {
 
         // Reuse the cached factorization when the matrix is unchanged (exact
         // `==` on the CSR triple). `b` is deliberately absent from the key, so
-        // a new right-hand side re-solves against the retained factor.
+        // a new right-hand side re-solves against the retained factor. This key
+        // comparison is O(nnz) per solve — inherent to safe reuse, since the
+        // factor can only be trusted after the matrix is verified — and it
+        // short-circuits on `ia` (length n+1) before touching `ja`/`a`.
         let cache_hit = self
             .cached
             .as_ref()
@@ -343,9 +363,14 @@ impl Pardiso {
         }
 
         // `self.cached` is `Some` here: either this was a cache hit, or the
-        // branch above just populated it.
-        let factor = &self.cached.as_ref().expect("factorization cached").factor;
-        let x = solve_with_factor(factor, n, b)?;
+        // branch above just populated it. The `ok_or_else` fallback is
+        // unreachable (both paths populate the cache), but returning an error
+        // keeps the no-panic guarantee rather than asserting an invariant the
+        // compiler cannot prove.
+        let cached = self.cached.as_ref().ok_or_else(|| {
+            Error::invalid("PARDISO: factorization cache missing after factor/populate")
+        })?;
+        let x = solve_with_factor(&cached.factor, n, b)?;
 
         // QR factorization of a singular matrix still succeeds (R is simply
         // rank-deficient), so Accelerate reports no error and the solve returns a
@@ -353,6 +378,25 @@ impl Pardiso {
         // singular systems error out like Intel PARDISO's zero-pivot failure.
         check_residual(ia, ja, a, b, &x)?;
         Ok(x)
+    }
+
+    /// Release the cached QR factorization and its matrix copies without
+    /// dropping the handle.
+    ///
+    /// The cache retains the factor plus full copies of the caller's CSR input
+    /// (`ia`/`ja`/`a`) for the handle's lifetime so repeated solves with an
+    /// unchanged matrix skip re-factoring — roughly 2–3× the matrix's `nnz`
+    /// storage on top of Accelerate's own factor copy. Call this to release
+    /// that memory (e.g. after a one-off solve, or before a long idle period);
+    /// the next [`Pardiso::solve`] re-factors from scratch.
+    pub fn reset(&mut self) {
+        if let Some(cached) = self.cached.take() {
+            let mut factor = cached.factor;
+            // SAFETY: `factor` is an owned, initialized factorization created by
+            // `_SparseFactorQR_Double`; destroyed exactly once here (the same
+            // release `Drop` performs).
+            unsafe { nuvai_mkl_sys::_SparseDestroyOpaqueNumeric_Double(&mut factor) };
+        }
     }
 }
 

--- a/crates/nuvai-mkl/src/vsl.rs
+++ b/crates/nuvai-mkl/src/vsl.rs
@@ -121,7 +121,14 @@ impl Stream {
             // single `Uniform` and fill the slice in one `sample_iter` pass.
             // RNG consumption order is unchanged (one draw per element), so a
             // fixed seed stays deterministic.
-            let distr = Uniform::new(a, b).expect("a < b was validated above");
+            //
+            // `Uniform::new` also rejects ranges whose span `b - a` overflows
+            // to infinity (e.g. `MIN..MAX`), which the `a < b` guard above does
+            // not catch. Surface that as an error so the aarch64 backend
+            // matches Intel VSL's error behaviour instead of panicking.
+            let distr = Uniform::new(a, b).map_err(|e| {
+                Error::invalid(format!("invalid uniform range [{a}, {b}): {e}"))
+            })?;
             let mut rng = self.state.borrow_mut();
             for (v, s) in out.iter_mut().zip(distr.sample_iter(&mut *rng)) {
                 *v = s;
@@ -173,7 +180,14 @@ impl Stream {
             // single `Uniform` and fill the slice in one `sample_iter` pass.
             // RNG consumption order is unchanged (one draw per element), so a
             // fixed seed stays deterministic.
-            let distr = Uniform::new(a, b).expect("a < b was validated above");
+            //
+            // `Uniform::new` also rejects ranges whose span `b - a` overflows
+            // to infinity (e.g. `MIN..MAX`), which the `a < b` guard above does
+            // not catch. Surface that as an error so the aarch64 backend
+            // matches Intel VSL's error behaviour instead of panicking.
+            let distr = Uniform::new(a, b).map_err(|e| {
+                Error::invalid(format!("invalid uniform range [{a}, {b}): {e}"))
+            })?;
             let mut rng = self.state.borrow_mut();
             for (v, s) in out.iter_mut().zip(distr.sample_iter(&mut *rng)) {
                 *v = s;

--- a/crates/nuvai-mkl/src/vsl.rs
+++ b/crates/nuvai-mkl/src/vsl.rs
@@ -19,13 +19,11 @@ use std::os::raw::c_int;
 use std::ptr;
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-use rand::RngExt;
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use rand::SeedableRng;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use rand_chacha::ChaCha20Rng;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-use rand_distr::{Distribution, Normal};
+use rand_distr::{Distribution, Normal, Uniform};
 
 use crate::error::{Error, Result};
 
@@ -119,9 +117,14 @@ impl Stream {
         }
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
+            // `random_range` re-validates the range on every element; hoist a
+            // single `Uniform` and fill the slice in one `sample_iter` pass.
+            // RNG consumption order is unchanged (one draw per element), so a
+            // fixed seed stays deterministic.
+            let distr = Uniform::new(a, b).expect("a < b was validated above");
             let mut rng = self.state.borrow_mut();
-            for v in out.iter_mut() {
-                *v = rng.random_range(a..b);
+            for (v, s) in out.iter_mut().zip(distr.sample_iter(&mut *rng)) {
+                *v = s;
             }
             Ok(())
         }
@@ -166,9 +169,14 @@ impl Stream {
         }
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
+            // `random_range` re-validates the range on every element; hoist a
+            // single `Uniform` and fill the slice in one `sample_iter` pass.
+            // RNG consumption order is unchanged (one draw per element), so a
+            // fixed seed stays deterministic.
+            let distr = Uniform::new(a, b).expect("a < b was validated above");
             let mut rng = self.state.borrow_mut();
-            for v in out.iter_mut() {
-                *v = rng.random_range(a..b);
+            for (v, s) in out.iter_mut().zip(distr.sample_iter(&mut *rng)) {
+                *v = s;
             }
             Ok(())
         }
@@ -208,8 +216,8 @@ impl Stream {
             let distr = Normal::new(mean, sigma)
                 .map_err(|e| Error::invalid(format!("gaussian: {e}")))?;
             let mut rng = self.state.borrow_mut();
-            for v in out.iter_mut() {
-                *v = distr.sample(&mut *rng);
+            for (v, s) in out.iter_mut().zip(distr.sample_iter(&mut *rng)) {
+                *v = s;
             }
             Ok(())
         }
@@ -249,8 +257,8 @@ impl Stream {
             let distr = Normal::new(mean, sigma)
                 .map_err(|e| Error::invalid(format!("gaussian: {e}")))?;
             let mut rng = self.state.borrow_mut();
-            for v in out.iter_mut() {
-                *v = distr.sample(&mut *rng);
+            for (v, s) in out.iter_mut().zip(distr.sample_iter(&mut *rng)) {
+                *v = s;
             }
             Ok(())
         }

--- a/crates/nuvai-mkl/tests/smoke.rs
+++ b/crates/nuvai-mkl/tests/smoke.rs
@@ -154,6 +154,56 @@ fn fft_roundtrip_c64() {
 
 #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
 #[test]
+fn fft_roundtrip_c32_len2() {
+    // 2 is the smallest split-complex fallback length (the interleaved family
+    // needs n >= 2, i.e. length >= 8). The impulse δ = [1,0] DFTs to all-ones
+    // and its inverse recovers it.
+    let plan = fft::FftPlan::new_c32(2).unwrap();
+    let input = [
+        MKL_Complex8 { real: 1.0, imag: 0.0 },
+        MKL_Complex8 { real: 0.0, imag: 0.0 },
+    ];
+    let mut freq = [MKL_Complex8 { real: 0.0, imag: 0.0 }; 2];
+    plan.forward_c32(&input, &mut freq).unwrap();
+    for f in &freq {
+        assert!((f.real - 1.0).abs() <= 1e-5, "real = {}", f.real);
+        assert!(f.imag.abs() <= 1e-5, "imag = {}", f.imag);
+    }
+
+    let mut out = [MKL_Complex8 { real: 0.0, imag: 0.0 }; 2];
+    plan.backward_c32(&freq, &mut out).unwrap();
+    assert!((out[0].real - 1.0).abs() <= 1e-5, "out[0] = {}", out[0].real);
+    for o in &out[1..] {
+        assert!(o.real.abs() <= 1e-5 && o.imag.abs() <= 1e-5);
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
+#[test]
+fn fft_roundtrip_c64_len2() {
+    // Double-precision analogue of `fft_roundtrip_c32_len2`.
+    let plan = fft::FftPlan::new_c64(2).unwrap();
+    let input = [
+        MKL_Complex16 { real: 1.0, imag: 0.0 },
+        MKL_Complex16 { real: 0.0, imag: 0.0 },
+    ];
+    let mut freq = [MKL_Complex16 { real: 0.0, imag: 0.0 }; 2];
+    plan.forward_c64(&input, &mut freq).unwrap();
+    for f in &freq {
+        assert!((f.real - 1.0).abs() <= 1e-9, "real = {}", f.real);
+        assert!(f.imag.abs() <= 1e-9, "imag = {}", f.imag);
+    }
+
+    let mut out = [MKL_Complex16 { real: 0.0, imag: 0.0 }; 2];
+    plan.backward_c64(&freq, &mut out).unwrap();
+    assert!((out[0].real - 1.0).abs() <= 1e-9, "out[0] = {}", out[0].real);
+    for o in &out[1..] {
+        assert!(o.real.abs() <= 1e-9 && o.imag.abs() <= 1e-9);
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
+#[test]
 fn fft_roundtrip_c32_non_pow2() {
     // 24 = 3·2^3 is not a power of two, so this exercises the non-power-of-two
     // path (DFTI on Intel; vDSP's interleaved `f·2^n` family on aarch64). As for
@@ -405,6 +455,21 @@ fn vsl_uniform_rejects_empty_range() {
     assert!(stream.uniform64(2.0, 1.0, &mut out64).is_err());
     assert!(stream.uniform64(f64::NAN, 1.0, &mut out64).is_err());
     assert!(stream.uniform64(0.0, f64::NAN, &mut out64).is_err());
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn vsl_uniform_rejects_nonfinite_span_on_aarch64() {
+    // `a < b` holds for `MIN..MAX`, but the span `b - a` overflows to infinity,
+    // which `rand`'s `Uniform::new` rejects. The aarch64 backend must surface
+    // that as an error (matching Intel VSL) rather than panicking on the old
+    // `.expect("a < b was validated above")`.
+    let stream = vsl::Stream::new(11).unwrap();
+    let mut out = [0.0f32; 4];
+    assert!(stream.uniform(f32::MIN, f32::MAX, &mut out).is_err());
+
+    let mut out64 = [0.0f64; 4];
+    assert!(stream.uniform64(f64::MIN, f64::MAX, &mut out64).is_err());
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/nuvai-mkl/tests/smoke.rs
+++ b/crates/nuvai-mkl/tests/smoke.rs
@@ -308,6 +308,28 @@ fn pardiso_solve_3x3() {
     assert_close64(&x, &[1.0, 2.0, 3.0], 1e-9);
 }
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn pardiso_reuses_factorization_on_aarch64() {
+    // Same nonsymmetric matrix as `pardiso_solve_3x3`, solved twice with two
+    // different right-hand sides. The second `solve` must reuse the cached QR
+    // factorization (`b` is not part of the cache key) and still return the
+    // correct solution.
+    let ia = [1i32, 3, 6, 8];
+    let ja = [1i32, 2, 1, 2, 3, 2, 3];
+    let a = [2.0f64, 1.0, 1.0, 3.0, 1.0, 1.0, 2.0];
+
+    let mut solver = pardiso::Pardiso::new(pardiso::mtype::NONSYMMETRIC);
+
+    let x1 = solver.solve(&ia, &ja, &a, &[4.0f64, 10.0, 8.0]).unwrap();
+    assert_close64(&x1, &[1.0, 2.0, 3.0], 1e-9);
+
+    // A·[3,1,2]ᵀ = [7,8,5]ᵀ — a distinct RHS that must not invalidate the
+    // cached factorization.
+    let x2 = solver.solve(&ia, &ja, &a, &[7.0f64, 8.0, 5.0]).unwrap();
+    assert_close64(&x2, &[3.0, 1.0, 2.0], 1e-9);
+}
+
 #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
 #[test]
 fn dss_solve_2x2() {

--- a/crates/nuvai-mkl/tests/smoke.rs
+++ b/crates/nuvai-mkl/tests/smoke.rs
@@ -156,9 +156,8 @@ fn fft_roundtrip_c64() {
 #[test]
 fn fft_roundtrip_c32_non_pow2() {
     // 24 = 3·2^3 is not a power of two, so this exercises the non-power-of-two
-    // path (DFTI on Intel; vDSP's `f·2^n` for `n >= 3` on aarch64 — note 6 =
-    // 3·2^1 is *not* implemented by vDSP). As for any length, the DFT of the
-    // impulse is all-ones and its inverse recovers it.
+    // path (DFTI on Intel; vDSP's interleaved `f·2^n` family on aarch64). As for
+    // any length, the DFT of the impulse is all-ones and its inverse recovers it.
     let plan = fft::FftPlan::new_c32(24).unwrap();
     let mut input = vec![MKL_Complex8 { real: 0.0, imag: 0.0 }; 24];
     input[0].real = 1.0;
@@ -174,6 +173,52 @@ fn fft_roundtrip_c32_non_pow2() {
     assert!((out[0].real - 1.0).abs() <= 1e-5, "out[0] = {}", out[0].real);
     for o in &out[1..] {
         assert!(o.real.abs() <= 1e-5 && o.imag.abs() <= 1e-5);
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
+#[test]
+fn fft_roundtrip_c32_len8() {
+    // 8 = 2·2^2 is the smallest length the interleaved-complex family plans
+    // (macOS 12.0+ on aarch64; DFTI on Intel), so this exercises that path
+    // directly rather than the split-complex fallback used for lengths 2 and 4.
+    let plan = fft::FftPlan::new_c32(8).unwrap();
+    let mut input = vec![MKL_Complex8 { real: 0.0, imag: 0.0 }; 8];
+    input[0].real = 1.0;
+    let mut freq = vec![MKL_Complex8 { real: 0.0, imag: 0.0 }; 8];
+    plan.forward_c32(&input, &mut freq).unwrap();
+    for f in &freq {
+        assert!((f.real - 1.0).abs() <= 1e-5, "real = {}", f.real);
+        assert!(f.imag.abs() <= 1e-5, "imag = {}", f.imag);
+    }
+
+    let mut out = vec![MKL_Complex8 { real: 0.0, imag: 0.0 }; 8];
+    plan.backward_c32(&freq, &mut out).unwrap();
+    assert!((out[0].real - 1.0).abs() <= 1e-5, "out[0] = {}", out[0].real);
+    for o in &out[1..] {
+        assert!(o.real.abs() <= 1e-5 && o.imag.abs() <= 1e-5);
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
+#[test]
+fn fft_roundtrip_c64_len8() {
+    // Double-precision analogue of `fft_roundtrip_c32_len8`.
+    let plan = fft::FftPlan::new_c64(8).unwrap();
+    let mut input = vec![MKL_Complex16 { real: 0.0, imag: 0.0 }; 8];
+    input[0].real = 1.0;
+    let mut freq = vec![MKL_Complex16 { real: 0.0, imag: 0.0 }; 8];
+    plan.forward_c64(&input, &mut freq).unwrap();
+    for f in &freq {
+        assert!((f.real - 1.0).abs() <= 1e-9, "real = {}", f.real);
+        assert!(f.imag.abs() <= 1e-9, "imag = {}", f.imag);
+    }
+
+    let mut out = vec![MKL_Complex16 { real: 0.0, imag: 0.0 }; 8];
+    plan.backward_c64(&freq, &mut out).unwrap();
+    assert!((out[0].real - 1.0).abs() <= 1e-9, "out[0] = {}", out[0].real);
+    for o in &out[1..] {
+        assert!(o.real.abs() <= 1e-9 && o.imag.abs() <= 1e-9);
     }
 }
 


### PR DESCRIPTION
Closes #13

Four non-blocking follow-ups from the PR #5 review, each in its own commit (trunk-based, targeting `main`):

1. **Unsafe lint hardening** — `#![deny(unsafe_op_in_unsafe_fn)]` + `#![deny(clippy::undocumented_unsafe_blocks)]` at the crate root (all existing `unsafe` blocks already carry `// SAFETY:` rationales).
2. **VSL bulk-fill** — `uniform`/`gaussian` fill slices in one `sample_iter` pass instead of per-element scalar loops (same RNG consumption order, so a fixed seed stays deterministic).
3. **PARDISO factorization reuse** — cache the QR factorization across `solve()` on aarch64, re-solving when the matrix is unchanged.
4. **FFT interleaved hybrid** — use vDSP's interleaved-complex DFT (no split/reinterleave copy) for lengths `f·2^n` it can plan; split-complex fallback for lengths 2 and 4. Bumps the aarch64-apple-darwin minimum to macOS 12.0.

Verification (native aarch64-apple-darwin): `cargo test --workspace` (23 pass) and `cargo clippy --workspace --all-targets -- -D warnings` are both green with the new deny lints enabled.