### PR TITLE
fix(blas): validate bounds, reject undersized slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — though
+the crate is pre-1.0, so breaking changes are permitted without a major bump.
+
+## [Unreleased]
+
+### Changed
+
+- **Breaking:** every `blas` routine now validates its operands and returns
+  `Result` before any pointer reaches CBLAS (issue #20). `sdot`/`ddot` change
+  from `f32`/`f64` to `Result<f32>`/`Result<f64>`; `saxpy`/`daxpy`/`sscal`/
+  `dscal`/`sgemm`/`dgemm` change from `()` to `Result<()>`, so calls that
+  previously could not fail may now return `ErrorKind::InvalidArgument`.
+
+- Level-1 strides and counts are now validated strictly: `n < 0`, `inc == 0`,
+  and `inc < 0` return `ErrorKind::InvalidArgument` instead of the no-op /
+  broadcast behavior of reference BLAS, matching the crate's LAPACK validation
+  which already rejects non-positive dimensions.
+
+### Fixed
+
+- `blas` level-1 routines reject negative strides. A negative stride was
+  previously accepted but walked *below* the slice (the wrapper passes the
+  slice's first element as the CBLAS base), making heap out-of-bounds
+  reads/writes reachable from safe code.

--- a/crates/nuvai-mkl-src/build.rs
+++ b/crates/nuvai-mkl-src/build.rs
@@ -33,8 +33,7 @@ fn main() {
     // The backend is a property of the *target* being built, not of the host
     // this build script runs on (see the module docs above).
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS is set");
-    let target_arch =
-        std::env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH is set");
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH is set");
     let target_env = std::env::var("CARGO_CFG_TARGET_ENV").ok();
 
     let backend = backend_for_target(&target_os, &target_arch, target_env.as_deref())

--- a/crates/nuvai-mkl-sys/build.rs
+++ b/crates/nuvai-mkl-sys/build.rs
@@ -54,12 +54,9 @@ fn main() {
         // because this crate declares no `links` key, so Cargo would drop it —
         // the backend already propagates via `nuvai-mkl-src` (`DEP_MKL_BACKEND`).
         ("macos", "aarch64") | ("linux", "aarch64") => {
-            let backend = nuvai_mkl_src::backend_for_target(
-                &target_os,
-                &target_arch,
-                target_env.as_deref(),
-            )
-            .unwrap_or_else(|e| panic!("{e}"));
+            let backend =
+                nuvai_mkl_src::backend_for_target(&target_os, &target_arch, target_env.as_deref())
+                    .unwrap_or_else(|e| panic!("{e}"));
             eprintln!(
                 "[nuvai-mkl-sys] {target_os}-{target_arch}: hand-written FFI surface ({})",
                 nuvai_mkl_src::backend_tag(backend)

--- a/crates/nuvai-mkl-sys/src/aarch64.rs
+++ b/crates/nuvai-mkl-sys/src/aarch64.rs
@@ -391,9 +391,7 @@ unsafe extern "C" {
         soln: *const DenseMatrix_Double,
         workspace: *mut c_void,
     );
-    pub fn _SparseDestroyOpaqueNumeric_Double(
-        toFree: *mut SparseOpaqueFactorization_Double,
-    );
+    pub fn _SparseDestroyOpaqueNumeric_Double(toFree: *mut SparseOpaqueFactorization_Double);
 
     // --- libc allocator (backs the default sparse `SparseSymbolicFactorOptions`)
     pub fn malloc(size: usize) -> *mut c_void;

--- a/crates/nuvai-mkl/src/blas.rs
+++ b/crates/nuvai-mkl/src/blas.rs
@@ -5,7 +5,8 @@
 //! pointer reaches CBLAS, mirroring `lapack::check_*_dims`. An undersized slice
 //! or leading dimension is rejected as `ErrorKind::InvalidArgument` rather than
 //! forwarded to MKL — which performs no bounds checking and would otherwise
-//! read/write out of bounds.
+//! read/write out of bounds. Level-1 strides must be positive (a zero or
+//! negative stride would index below the slice).
 
 use crate::error::{Error, Result};
 use crate::layout::{Layout, Transpose};
@@ -44,6 +45,10 @@ fn cblas_trans(trans: Transpose) -> CblasEnum {
 /// cover its stored columns (row-major) or rows (column-major), and its slice
 /// must reach the trailing element CBLAS touches. Rejects undersized buffers —
 /// otherwise a safe call would be a heap out-of-bounds read/write inside MKL.
+///
+/// The leading dimensions are checked even when `alpha == 0`: BLAS enforces
+/// `lda`/`ldb`/`ldc` before its "quick return", so an invalid `ld` is rejected
+/// regardless of whether the operand values are actually read.
 fn check_gemm_dims(
     layout: Layout,
     transa: Transpose,
@@ -106,6 +111,11 @@ fn check_matrix(
 }
 
 /// Validate a level-1 vector argument: `n` elements at stride `inc`.
+///
+/// `inc` must be positive. A zero increment is invalid per the BLAS spec, and a
+/// negative one is rejected outright: the wrapper passes the slice's *first*
+/// element as the CBLAS base, so a negative stride would make CBLAS index below
+/// the slice — a heap out-of-bounds access that a `&[T]` cannot represent.
 fn check_vector(n: i32, len: usize, inc: i32, name: &str) -> Result<()> {
     if n < 0 {
         return Err(Error::invalid(format!("blas: {name} count is negative")));
@@ -113,10 +123,12 @@ fn check_vector(n: i32, len: usize, inc: i32, name: &str) -> Result<()> {
     if n == 0 {
         return Ok(());
     }
-    if inc == 0 {
-        return Err(Error::invalid(format!("blas: {name} increment is zero")));
+    if inc <= 0 {
+        return Err(Error::invalid(format!(
+            "blas: {name} increment must be positive"
+        )));
     }
-    let required = 1 + (n - 1) as usize * inc.unsigned_abs() as usize;
+    let required = 1 + (n - 1) as usize * inc as usize;
     if len < required {
         return Err(Error::invalid(format!("blas: {name} too short")));
     }
@@ -145,7 +157,18 @@ pub fn sgemm(
     ldc: i32,
 ) -> Result<()> {
     check_gemm_dims(
-        layout, transa, transb, m, n, k, a.len(), lda, b.len(), ldb, c.len(), ldc,
+        layout,
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        a.len(),
+        lda,
+        b.len(),
+        ldb,
+        c.len(),
+        ldc,
     )?;
     // SAFETY: `a`, `b` and `c` cover the transpose-adjusted leading-dimension
     // region `cblas_sgemm` reads/writes, as enforced by `check_gemm_dims` above.
@@ -189,7 +212,18 @@ pub fn dgemm(
     ldc: i32,
 ) -> Result<()> {
     check_gemm_dims(
-        layout, transa, transb, m, n, k, a.len(), lda, b.len(), ldb, c.len(), ldc,
+        layout,
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        a.len(),
+        lda,
+        b.len(),
+        ldb,
+        c.len(),
+        ldc,
     )?;
     // SAFETY: `a`, `b` and `c` cover the transpose-adjusted leading-dimension
     // region `cblas_dgemm` reads/writes, as enforced by `check_gemm_dims` above.

--- a/crates/nuvai-mkl/src/blas.rs
+++ b/crates/nuvai-mkl/src/blas.rs
@@ -1,11 +1,13 @@
 //! BLAS (Basic Linear Algebra Subprograms) via the CBLAS interface.
 //!
 //! Dense linear-algebra primitives. Every routine takes slices and leading
-//! dimensions; the caller is responsible for sizing buffers to the BLAS
-//! convention (documented per function). MKL performs no bounds checking, so
-//! an under-sized slice is undefined behaviour exactly as in C.
+//! dimensions and validates them against the BLAS sizing convention before any
+//! pointer reaches CBLAS, mirroring `lapack::check_*_dims`. An undersized slice
+//! or leading dimension is rejected as `ErrorKind::InvalidArgument` rather than
+//! forwarded to MKL — which performs no bounds checking and would otherwise
+//! read/write out of bounds.
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::layout::{Layout, Transpose};
 
 /// Integer type the FFI CBLAS enums use on this target. bindgen maps the C
@@ -35,6 +37,92 @@ fn cblas_trans(trans: Transpose) -> CblasEnum {
     }
 }
 
+/// Validate a `?gemm` call's buffers before any pointer reaches CBLAS.
+///
+/// `op(A)` is `m × k` (`k × m` when transposed), `op(B)` is `k × n` (`n × k`
+/// when transposed) and `C` is `m × n`. Each operand's leading dimension must
+/// cover its stored columns (row-major) or rows (column-major), and its slice
+/// must reach the trailing element CBLAS touches. Rejects undersized buffers —
+/// otherwise a safe call would be a heap out-of-bounds read/write inside MKL.
+fn check_gemm_dims(
+    layout: Layout,
+    transa: Transpose,
+    transb: Transpose,
+    m: i32,
+    n: i32,
+    k: i32,
+    a_len: usize,
+    lda: i32,
+    b_len: usize,
+    ldb: i32,
+    c_len: usize,
+    ldc: i32,
+) -> Result<()> {
+    if m < 0 || n < 0 || k < 0 {
+        return Err(Error::invalid("blas: m, n and k must be non-negative"));
+    }
+    let (a_rows, a_cols) = match transa {
+        Transpose::NoTrans => (m, k),
+        Transpose::Trans | Transpose::ConjTrans => (k, m),
+    };
+    let (b_rows, b_cols) = match transb {
+        Transpose::NoTrans => (k, n),
+        Transpose::Trans | Transpose::ConjTrans => (n, k),
+    };
+    check_matrix(layout, a_rows, a_cols, lda, a_len, "a", "lda")?;
+    check_matrix(layout, b_rows, b_cols, ldb, b_len, "b", "ldb")?;
+    check_matrix(layout, m, n, ldc, c_len, "c", "ldc")?;
+    Ok(())
+}
+
+/// Validate one `rows × cols` operand with leading dimension `ld`.
+fn check_matrix(
+    layout: Layout,
+    rows: i32,
+    cols: i32,
+    ld: i32,
+    len: usize,
+    name: &str,
+    ld_name: &str,
+) -> Result<()> {
+    if rows == 0 || cols == 0 {
+        return Ok(());
+    }
+    let min_ld = match layout {
+        Layout::RowMajor => cols,
+        Layout::ColMajor => rows,
+    };
+    if ld < min_ld {
+        return Err(Error::invalid(format!("blas: {ld_name} < {min_ld}")));
+    }
+    let min_len = match layout {
+        Layout::RowMajor => (rows - 1) as usize * ld as usize + cols as usize,
+        Layout::ColMajor => (cols - 1) as usize * ld as usize + rows as usize,
+    };
+    if len < min_len {
+        return Err(Error::invalid(format!("blas: {name} too short")));
+    }
+    Ok(())
+}
+
+/// Validate a level-1 vector argument: `n` elements at stride `inc`.
+fn check_vector(n: i32, len: usize, inc: i32, name: &str) -> Result<()> {
+    if n < 0 {
+        return Err(Error::invalid(format!("blas: {name} count is negative")));
+    }
+    if n == 0 {
+        return Ok(());
+    }
+    if inc == 0 {
+        return Err(Error::invalid(format!("blas: {name} increment is zero")));
+    }
+    let required = 1 + (n - 1) as usize * inc.unsigned_abs() as usize;
+    if len < required {
+        return Err(Error::invalid(format!("blas: {name} too short")));
+    }
+    Ok(())
+}
+
 /// `C := alpha * op(A) * op(B) + beta * C`, single precision.
 ///
 /// `A` is `m × k` (or `k × m` when transposed), `B` is `k × n` (or `n × k`),
@@ -56,10 +144,11 @@ pub fn sgemm(
     c: &mut [f32],
     ldc: i32,
 ) -> Result<()> {
-    // SAFETY: soundness relies on the caller upholding the documented BLAS
-    // sizing contract (module header) — `a`/`b`/`c` must cover the
-    // transpose-adjusted `lda`/`ldb`/`ldc` elements `cblas_sgemm` reads/writes.
-    // This wrapper is a pass-through with no bounds checks, exactly like CBLAS.
+    check_gemm_dims(
+        layout, transa, transb, m, n, k, a.len(), lda, b.len(), ldb, c.len(), ldc,
+    )?;
+    // SAFETY: `a`, `b` and `c` cover the transpose-adjusted leading-dimension
+    // region `cblas_sgemm` reads/writes, as enforced by `check_gemm_dims` above.
     unsafe {
         nuvai_mkl_sys::cblas_sgemm(
             cblas_layout(layout),
@@ -99,9 +188,11 @@ pub fn dgemm(
     c: &mut [f64],
     ldc: i32,
 ) -> Result<()> {
-    // SAFETY: caller must size `a`/`b`/`c` per the BLAS convention (module
-    // header); `cblas_dgemm` reads/writes those transpose-adjusted leading-
-    // dimension elements via the forwarded raw pointers.
+    check_gemm_dims(
+        layout, transa, transb, m, n, k, a.len(), lda, b.len(), ldb, c.len(), ldc,
+    )?;
+    // SAFETY: `a`, `b` and `c` cover the transpose-adjusted leading-dimension
+    // region `cblas_dgemm` reads/writes, as enforced by `check_gemm_dims` above.
     unsafe {
         nuvai_mkl_sys::cblas_dgemm(
             cblas_layout(layout),
@@ -125,8 +216,11 @@ pub fn dgemm(
 
 /// `y := alpha * x + y`, single precision.
 pub fn saxpy(n: i32, alpha: f32, x: &[f32], incx: i32, y: &mut [f32], incy: i32) -> Result<()> {
-    // SAFETY: caller must size `x`/`y` to `n` elements at strides `incx`/`incy`
-    // per the BLAS convention (module header); `cblas_saxpy` reads/writes them.
+    check_vector(n, x.len(), incx, "x")?;
+    check_vector(n, y.len(), incy, "y")?;
+    // SAFETY: `x` and `y` hold `n` elements at strides `incx`/`incy`, as
+    // enforced by `check_vector` above; `cblas_saxpy` reads `x`, reads/writes
+    // `y`.
     unsafe {
         nuvai_mkl_sys::cblas_saxpy(n, alpha, x.as_ptr(), incx, y.as_mut_ptr(), incy);
     }
@@ -135,8 +229,11 @@ pub fn saxpy(n: i32, alpha: f32, x: &[f32], incx: i32, y: &mut [f32], incy: i32)
 
 /// `y := alpha * x + y`, double precision.
 pub fn daxpy(n: i32, alpha: f64, x: &[f64], incx: i32, y: &mut [f64], incy: i32) -> Result<()> {
-    // SAFETY: caller must size `x`/`y` to `n` elements at strides `incx`/`incy`
-    // per the BLAS convention (module header); `cblas_daxpy` reads/writes them.
+    check_vector(n, x.len(), incx, "x")?;
+    check_vector(n, y.len(), incy, "y")?;
+    // SAFETY: `x` and `y` hold `n` elements at strides `incx`/`incy`, as
+    // enforced by `check_vector` above; `cblas_daxpy` reads `x`, reads/writes
+    // `y`.
     unsafe {
         nuvai_mkl_sys::cblas_daxpy(n, alpha, x.as_ptr(), incx, y.as_mut_ptr(), incy);
     }
@@ -144,23 +241,28 @@ pub fn daxpy(n: i32, alpha: f64, x: &[f64], incx: i32, y: &mut [f64], incy: i32)
 }
 
 /// `dot := xᵀ · y`, single precision.
-pub fn sdot(n: i32, x: &[f32], incx: i32, y: &[f32], incy: i32) -> f32 {
-    // SAFETY: caller must size `x`/`y` to `n` elements at strides `incx`/`incy`
-    // per the BLAS convention; `cblas_sdot` only reads them.
-    unsafe { nuvai_mkl_sys::cblas_sdot(n, x.as_ptr(), incx, y.as_ptr(), incy) }
+pub fn sdot(n: i32, x: &[f32], incx: i32, y: &[f32], incy: i32) -> Result<f32> {
+    check_vector(n, x.len(), incx, "x")?;
+    check_vector(n, y.len(), incy, "y")?;
+    // SAFETY: `x` and `y` hold `n` elements at strides `incx`/`incy`, as
+    // enforced by `check_vector` above; `cblas_sdot` only reads them.
+    Ok(unsafe { nuvai_mkl_sys::cblas_sdot(n, x.as_ptr(), incx, y.as_ptr(), incy) })
 }
 
 /// `dot := xᵀ · y`, double precision.
-pub fn ddot(n: i32, x: &[f64], incx: i32, y: &[f64], incy: i32) -> f64 {
-    // SAFETY: caller must size `x`/`y` to `n` elements at strides `incx`/`incy`
-    // per the BLAS convention; `cblas_ddot` only reads them.
-    unsafe { nuvai_mkl_sys::cblas_ddot(n, x.as_ptr(), incx, y.as_ptr(), incy) }
+pub fn ddot(n: i32, x: &[f64], incx: i32, y: &[f64], incy: i32) -> Result<f64> {
+    check_vector(n, x.len(), incx, "x")?;
+    check_vector(n, y.len(), incy, "y")?;
+    // SAFETY: `x` and `y` hold `n` elements at strides `incx`/`incy`, as
+    // enforced by `check_vector` above; `cblas_ddot` only reads them.
+    Ok(unsafe { nuvai_mkl_sys::cblas_ddot(n, x.as_ptr(), incx, y.as_ptr(), incy) })
 }
 
 /// `x := alpha * x`, single precision.
 pub fn sscal(n: i32, alpha: f32, x: &mut [f32], incx: i32) -> Result<()> {
-    // SAFETY: caller must size `x` to `n` elements at stride `incx` per the
-    // BLAS convention (module header); `cblas_sscal` writes them.
+    check_vector(n, x.len(), incx, "x")?;
+    // SAFETY: `x` holds `n` elements at stride `incx`, as enforced by
+    // `check_vector` above; `cblas_sscal` writes them.
     unsafe {
         nuvai_mkl_sys::cblas_sscal(n, alpha, x.as_mut_ptr(), incx);
     }
@@ -169,8 +271,9 @@ pub fn sscal(n: i32, alpha: f32, x: &mut [f32], incx: i32) -> Result<()> {
 
 /// `x := alpha * x`, double precision.
 pub fn dscal(n: i32, alpha: f64, x: &mut [f64], incx: i32) -> Result<()> {
-    // SAFETY: caller must size `x` to `n` elements at stride `incx` per the
-    // BLAS convention (module header); `cblas_dscal` writes them.
+    check_vector(n, x.len(), incx, "x")?;
+    // SAFETY: `x` holds `n` elements at stride `incx`, as enforced by
+    // `check_vector` above; `cblas_dscal` writes them.
     unsafe {
         nuvai_mkl_sys::cblas_dscal(n, alpha, x.as_mut_ptr(), incx);
     }

--- a/crates/nuvai-mkl/src/dss.rs
+++ b/crates/nuvai-mkl/src/dss.rs
@@ -20,10 +20,10 @@
 //! flags to [`dss_solve_real_`]. Only the indexing/precision flags
 //! (`MKL_DSS_ZERO_BASED_INDEXING`) are passed to [`dss_create_`].
 
-#[cfg(not(target_arch = "aarch64"))]
-use std::os::raw::c_void;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use std::os::raw::c_long;
+#[cfg(not(target_arch = "aarch64"))]
+use std::os::raw::c_void;
 #[cfg(not(target_arch = "aarch64"))]
 use std::ptr;
 

--- a/crates/nuvai-mkl/src/fft.rs
+++ b/crates/nuvai-mkl/src/fft.rs
@@ -20,7 +20,7 @@ use std::ptr;
 
 use crate::error::{Error, Result};
 
-pub use nuvai_mkl_sys::{MKL_Complex16, MKL_Complex8};
+pub use nuvai_mkl_sys::{MKL_Complex8, MKL_Complex16};
 
 /// Opaque plan handle. On Intel this is the committed DFTI descriptor; on
 /// aarch64 it holds the forward + inverse vDSP DFT setups and the precision.
@@ -189,18 +189,28 @@ impl FftPlan {
             if status != 0 {
                 // SAFETY: `handle` is a valid descriptor, freed exactly once here.
                 unsafe { nuvai_mkl_sys::DftiFreeDescriptor(&mut handle) };
-                return Err(Error::mkl(status as i32, "DftiSetValue(DFTI_FORWARD_SCALE)"));
+                return Err(Error::mkl(
+                    status as i32,
+                    "DftiSetValue(DFTI_FORWARD_SCALE)",
+                ));
             }
             let backward_scale = 1.0f64 / len as f64;
             // SAFETY: `handle` is a valid descriptor; `DFTI_BACKWARD_SCALE` with
             // the computed `1/len` value is valid config.
             let status = unsafe {
-                nuvai_mkl_sys::DftiSetValue(handle, nuvai_mkl_sys::DFTI_BACKWARD_SCALE, backward_scale)
+                nuvai_mkl_sys::DftiSetValue(
+                    handle,
+                    nuvai_mkl_sys::DFTI_BACKWARD_SCALE,
+                    backward_scale,
+                )
             };
             if status != 0 {
                 // SAFETY: `handle` is a valid descriptor, freed exactly once here.
                 unsafe { nuvai_mkl_sys::DftiFreeDescriptor(&mut handle) };
-                return Err(Error::mkl(status as i32, "DftiSetValue(DFTI_BACKWARD_SCALE)"));
+                return Err(Error::mkl(
+                    status as i32,
+                    "DftiSetValue(DFTI_BACKWARD_SCALE)",
+                ));
             }
             // SAFETY: `handle` is a valid, fully-configured descriptor.
             let status = unsafe { nuvai_mkl_sys::DftiCommitDescriptor(handle) };
@@ -315,7 +325,11 @@ impl FftPlan {
     }
 
     /// Backward transform (double precision), `input → output` (scaled by `1/n`).
-    pub fn backward_c64(&self, input: &[MKL_Complex16], output: &mut [MKL_Complex16]) -> Result<()> {
+    pub fn backward_c64(
+        &self,
+        input: &[MKL_Complex16],
+        output: &mut [MKL_Complex16],
+    ) -> Result<()> {
         self.check(input.len(), output.len())?;
         #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
         {
@@ -383,10 +397,7 @@ impl FftPlan {
     /// Try to plan the interleaved-complex family. Returns `None` when the
     /// length is unsupported (vDSP returns a null setup), signalling `create`
     /// to fall back to the split family.
-    fn create_interleaved(
-        length: nuvai_mkl_sys::vDSP_Length,
-        single: bool,
-    ) -> Option<FftBackend> {
+    fn create_interleaved(length: nuvai_mkl_sys::vDSP_Length, single: bool) -> Option<FftBackend> {
         let complextocomplex = nuvai_mkl_sys::vDSP_DFT_Interleaved_ComplextoComplex;
         // SAFETY: `CreateSetup`/`CreateSetupD` take a null `prev` setup and the
         // positive `length`, returning a new setup (or null on failure). Each
@@ -521,7 +532,10 @@ impl FftPlan {
     fn transform_c32(&self, input: &[MKL_Complex8], output: &mut [MKL_Complex8], inverse: bool) {
         let n = self.len;
         match &self.handle.backend {
-            FftBackend::Interleaved { forward, inverse: inv } => {
+            FftBackend::Interleaved {
+                forward,
+                inverse: inv,
+            } => {
                 let setup = if inverse { *inv } else { *forward };
                 // `DSPComplex` is layout-identical to `MKL_Complex8` (both
                 // `#[repr(C)] { real: f32, imag: f32 }`), so the caller's
@@ -583,7 +597,10 @@ impl FftPlan {
     fn transform_c64(&self, input: &[MKL_Complex16], output: &mut [MKL_Complex16], inverse: bool) {
         let n = self.len;
         match &self.handle.backend {
-            FftBackend::Interleaved { forward, inverse: inv } => {
+            FftBackend::Interleaved {
+                forward,
+                inverse: inv,
+            } => {
                 let setup = if inverse { *inv } else { *forward };
                 // `DSPDoubleComplex` is layout-identical to `MKL_Complex16`
                 // (both `#[repr(C)] { real: f64, imag: f64 }`), so the caller's
@@ -666,7 +683,9 @@ impl Drop for FftPlan {
                         }
                     }
                 }
-                FftBackend::Split { forward, inverse, .. } => {
+                FftBackend::Split {
+                    forward, inverse, ..
+                } => {
                     // SAFETY: `forward`/`inverse` are valid split setups created
                     // non-null in `create_split`, and each is destroyed exactly
                     // once here via the precision-matched destroy routine.

--- a/crates/nuvai-mkl/src/lapack.rs
+++ b/crates/nuvai-mkl/src/lapack.rs
@@ -209,7 +209,14 @@ pub fn sgetrf(
         // SAFETY: `a` covers `lda·n` elements and `ipiv` covers `min(m,n)`,
         // per `check_factor_dims` above; `m`, `n`, `lda` are non-negative.
         let info = unsafe {
-            nuvai_mkl_sys::LAPACKE_sgetrf(lapacke_layout(layout), m, n, a.as_mut_ptr(), lda, ipiv.as_mut_ptr())
+            nuvai_mkl_sys::LAPACKE_sgetrf(
+                lapacke_layout(layout),
+                m,
+                n,
+                a.as_mut_ptr(),
+                lda,
+                ipiv.as_mut_ptr(),
+            )
         };
         if info != 0 {
             return Err(Error::mkl(info, "LAPACKE_sgetrf"));
@@ -237,7 +244,14 @@ pub fn dgetrf(
         // SAFETY: `a` covers `lda·n` elements and `ipiv` covers `min(m,n)`,
         // per `check_factor_dims` above.
         let info = unsafe {
-            nuvai_mkl_sys::LAPACKE_dgetrf(lapacke_layout(layout), m, n, a.as_mut_ptr(), lda, ipiv.as_mut_ptr())
+            nuvai_mkl_sys::LAPACKE_dgetrf(
+                lapacke_layout(layout),
+                m,
+                n,
+                a.as_mut_ptr(),
+                lda,
+                ipiv.as_mut_ptr(),
+            )
         };
         if info != 0 {
             return Err(Error::mkl(info, "LAPACKE_dgetrf"));
@@ -435,7 +449,14 @@ mod aarch64 {
         Ok(())
     }
 
-    pub fn sgetrf(layout: Layout, m: i32, n: i32, a: &mut [f32], lda: i32, ipiv: &mut [i32]) -> Result<()> {
+    pub fn sgetrf(
+        layout: Layout,
+        m: i32,
+        n: i32,
+        a: &mut [f32],
+        lda: i32,
+        ipiv: &mut [i32],
+    ) -> Result<()> {
         check_factor_dims(layout, m, n, a.len(), lda, ipiv.len())?;
         let info = match layout {
             Layout::ColMajor => {
@@ -443,7 +464,14 @@ mod aarch64 {
                 // SAFETY: `a` covers `lda·n` and `ipiv` covers `min(m,n)`
                 // (validated above); `info` is a valid out-arg.
                 unsafe {
-                    nuvai_mkl_sys::sgetrf_(&m, &n, a.as_mut_ptr(), &lda, ipiv.as_mut_ptr(), &mut info);
+                    nuvai_mkl_sys::sgetrf_(
+                        &m,
+                        &n,
+                        a.as_mut_ptr(),
+                        &lda,
+                        ipiv.as_mut_ptr(),
+                        &mut info,
+                    );
                 }
                 info
             }
@@ -456,7 +484,14 @@ mod aarch64 {
                 // SAFETY: `a_cm` is freshly allocated to `m·n`; `ipiv` covers
                 // `min(m,n)`; `info` is a valid out-arg.
                 unsafe {
-                    nuvai_mkl_sys::sgetrf_(&m, &n, a_cm.as_mut_ptr(), &lda_cm, ipiv.as_mut_ptr(), &mut info);
+                    nuvai_mkl_sys::sgetrf_(
+                        &m,
+                        &n,
+                        a_cm.as_mut_ptr(),
+                        &lda_cm,
+                        ipiv.as_mut_ptr(),
+                        &mut info,
+                    );
                 }
                 if info == 0 {
                     // Copy the factored matrix back to row-major (LAPACKE parity).
@@ -471,7 +506,14 @@ mod aarch64 {
         Ok(())
     }
 
-    pub fn dgetrf(layout: Layout, m: i32, n: i32, a: &mut [f64], lda: i32, ipiv: &mut [i32]) -> Result<()> {
+    pub fn dgetrf(
+        layout: Layout,
+        m: i32,
+        n: i32,
+        a: &mut [f64],
+        lda: i32,
+        ipiv: &mut [i32],
+    ) -> Result<()> {
         check_factor_dims(layout, m, n, a.len(), lda, ipiv.len())?;
         let info = match layout {
             Layout::ColMajor => {
@@ -479,7 +521,14 @@ mod aarch64 {
                 // SAFETY: `a` covers `lda·n` and `ipiv` covers `min(m,n)`
                 // (validated above); `info` is a valid out-arg.
                 unsafe {
-                    nuvai_mkl_sys::dgetrf_(&m, &n, a.as_mut_ptr(), &lda, ipiv.as_mut_ptr(), &mut info);
+                    nuvai_mkl_sys::dgetrf_(
+                        &m,
+                        &n,
+                        a.as_mut_ptr(),
+                        &lda,
+                        ipiv.as_mut_ptr(),
+                        &mut info,
+                    );
                 }
                 info
             }
@@ -491,7 +540,14 @@ mod aarch64 {
                 // SAFETY: `a_cm` is freshly allocated to `m·n`; `ipiv` covers
                 // `min(m,n)`; `info` is a valid out-arg.
                 unsafe {
-                    nuvai_mkl_sys::dgetrf_(&m, &n, a_cm.as_mut_ptr(), &lda_cm, ipiv.as_mut_ptr(), &mut info);
+                    nuvai_mkl_sys::dgetrf_(
+                        &m,
+                        &n,
+                        a_cm.as_mut_ptr(),
+                        &lda_cm,
+                        ipiv.as_mut_ptr(),
+                        &mut info,
+                    );
                 }
                 if info == 0 {
                     col_to_row_f64(&a_cm, m, n, a, lda);

--- a/crates/nuvai-mkl/src/pardiso.rs
+++ b/crates/nuvai-mkl/src/pardiso.rs
@@ -13,19 +13,19 @@
 // `c_void`/`ptr` are used by the Intel path and the Accelerate (macOS-aarch64)
 // helpers but not by the linux-aarch64 Unsupported path, so gate them to every
 // target except the inert linux-aarch64 arm.
-#[cfg(any(
-    all(target_os = "macos", target_arch = "aarch64"),
-    not(target_arch = "aarch64")
-))]
-use std::os::raw::c_void;
+use std::marker::PhantomData;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use std::os::raw::c_long;
 #[cfg(any(
     all(target_os = "macos", target_arch = "aarch64"),
     not(target_arch = "aarch64")
 ))]
+use std::os::raw::c_void;
+#[cfg(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    not(target_arch = "aarch64")
+))]
 use std::ptr;
-use std::marker::PhantomData;
 
 use crate::error::{Error, Result};
 
@@ -111,7 +111,11 @@ impl Pardiso {
             // size `pardisoinit` expects to initialize; `mtype` is passed by
             // const reference and only read.
             unsafe {
-                nuvai_mkl_sys::pardisoinit(pt.as_mut_ptr() as *mut c_void, &mtype, iparm.as_mut_ptr());
+                nuvai_mkl_sys::pardisoinit(
+                    pt.as_mut_ptr() as *mut c_void,
+                    &mtype,
+                    iparm.as_mut_ptr(),
+                );
             }
             Self {
                 pt,
@@ -274,7 +278,13 @@ impl Pardiso {
 /// CSC buffers can be dropped after factoring.
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 impl Pardiso {
-    fn solve_accelerate(&mut self, ia: &[i32], ja: &[i32], a: &[f64], b: &[f64]) -> Result<Vec<f64>> {
+    fn solve_accelerate(
+        &mut self,
+        ia: &[i32],
+        ja: &[i32],
+        a: &[f64],
+        b: &[f64],
+    ) -> Result<Vec<f64>> {
         // The Accelerate QR backend factors a *full* (ordinary) matrix. PARDISO's
         // symmetric `mtype`s (SPD / symmetric indefinite) store only one triangle,
         // which QR would read as a full matrix and silently mis-solve. Reject them
@@ -424,7 +434,9 @@ pub(crate) fn csr_to_csc(
     // base, and a non-decreasing row_index. Any other shape would silently drop
     // or mis-index entries.
     if row_index[0] != base {
-        return Err(Error::invalid("CSR row_index[0] does not match the index base"));
+        return Err(Error::invalid(
+            "CSR row_index[0] does not match the index base",
+        ));
     }
     if row_index[n] != nnz as i32 + base {
         return Err(Error::invalid("CSR row_index[n] does not match nnz"));

--- a/crates/nuvai-mkl/src/vsl.rs
+++ b/crates/nuvai-mkl/src/vsl.rs
@@ -126,9 +126,8 @@ impl Stream {
             // to infinity (e.g. `MIN..MAX`), which the `a < b` guard above does
             // not catch. Surface that as an error so the aarch64 backend
             // matches Intel VSL's error behaviour instead of panicking.
-            let distr = Uniform::new(a, b).map_err(|e| {
-                Error::invalid(format!("invalid uniform range [{a}, {b}): {e}"))
-            })?;
+            let distr = Uniform::new(a, b)
+                .map_err(|e| Error::invalid(format!("invalid uniform range [{a}, {b}): {e}")))?;
             let mut rng = self.state.borrow_mut();
             for (v, s) in out.iter_mut().zip(distr.sample_iter(&mut *rng)) {
                 *v = s;
@@ -185,9 +184,8 @@ impl Stream {
             // to infinity (e.g. `MIN..MAX`), which the `a < b` guard above does
             // not catch. Surface that as an error so the aarch64 backend
             // matches Intel VSL's error behaviour instead of panicking.
-            let distr = Uniform::new(a, b).map_err(|e| {
-                Error::invalid(format!("invalid uniform range [{a}, {b}): {e}"))
-            })?;
+            let distr = Uniform::new(a, b)
+                .map_err(|e| Error::invalid(format!("invalid uniform range [{a}, {b}): {e}")))?;
             let mut rng = self.state.borrow_mut();
             for (v, s) in out.iter_mut().zip(distr.sample_iter(&mut *rng)) {
                 *v = s;
@@ -227,8 +225,8 @@ impl Stream {
         }
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
-            let distr = Normal::new(mean, sigma)
-                .map_err(|e| Error::invalid(format!("gaussian: {e}")))?;
+            let distr =
+                Normal::new(mean, sigma).map_err(|e| Error::invalid(format!("gaussian: {e}")))?;
             let mut rng = self.state.borrow_mut();
             for (v, s) in out.iter_mut().zip(distr.sample_iter(&mut *rng)) {
                 *v = s;
@@ -268,8 +266,8 @@ impl Stream {
         }
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
-            let distr = Normal::new(mean, sigma)
-                .map_err(|e| Error::invalid(format!("gaussian: {e}")))?;
+            let distr =
+                Normal::new(mean, sigma).map_err(|e| Error::invalid(format!("gaussian: {e}")))?;
             let mut rng = self.state.borrow_mut();
             for (v, s) in out.iter_mut().zip(distr.sample_iter(&mut *rng)) {
                 *v = s;

--- a/crates/nuvai-mkl/tests/smoke.rs
+++ b/crates/nuvai-mkl/tests/smoke.rs
@@ -55,8 +55,74 @@ fn blas_axpy_dot() {
     blas::saxpy(3, 2.0, &x, 1, &mut y, 1).unwrap();
     assert_close(&y, &[12.0, 24.0, 36.0], 1e-5);
 
-    let dot = blas::sdot(3, &x, 1, &[4.0, 5.0, 6.0], 1);
+    let dot = blas::sdot(3, &x, 1, &[4.0, 5.0, 6.0], 1).unwrap();
     assert!((dot - 32.0).abs() <= 1e-5, "dot = {dot}");
+}
+
+#[test]
+fn blas_rejects_undersized_slices() {
+    // #20: an undersized operand must error, not drive MKL into a heap OOB
+    // read/write reachable from safe code. The huge `m` with a 4-element `a`
+    // is the exact UB shape from the issue.
+    let a = [1.0f32; 4];
+    let b = [1.0f32; 4];
+    let mut c = [0.0f32; 4];
+    assert!(blas::sgemm(
+        Layout::RowMajor,
+        Transpose::NoTrans,
+        Transpose::NoTrans,
+        100_000,
+        2,
+        2,
+        1.0,
+        &a,
+        2,
+        &b,
+        2,
+        0.0,
+        &mut c,
+        2,
+    )
+    .is_err());
+
+    // Leading dimension below the stored width (row-major `lda < k`).
+    let a = [1.0f32; 4];
+    let b = [1.0f32; 4];
+    let mut c = [0.0f32; 4];
+    assert!(blas::sgemm(
+        Layout::RowMajor,
+        Transpose::NoTrans,
+        Transpose::NoTrans,
+        2,
+        2,
+        2,
+        1.0,
+        &a,
+        1,
+        &b,
+        2,
+        0.0,
+        &mut c,
+        2,
+    )
+    .is_err());
+
+    // Level-1: undersized, zero stride, and negative count are all invalid.
+    let x = [1.0f32; 2];
+    let mut y = [0.0f32; 2];
+    assert!(blas::saxpy(3, 1.0, &x, 1, &mut y, 1).is_err());
+    assert!(blas::saxpy(3, 1.0, &x, 0, &mut y, 1).is_err());
+    assert!(blas::saxpy(-1, 1.0, &x, 1, &mut y, 1).is_err());
+
+    // `sdot`/`ddot` now return `Result`.
+    assert!(blas::sdot(3, &x, 1, &[1.0f32; 2], 1).is_err());
+    assert!(blas::ddot(3, &[1.0f64; 2], 1, &[1.0f64; 2], 1).is_err());
+
+    // `sscal`/`dscal` undersized.
+    let mut xs = [1.0f32; 2];
+    assert!(blas::sscal(3, 2.0, &mut xs, 1).is_err());
+    let mut xd = [1.0f64; 2];
+    assert!(blas::dscal(3, 2.0, &mut xd, 1).is_err());
 }
 
 #[test]

--- a/crates/nuvai-mkl/tests/smoke.rs
+++ b/crates/nuvai-mkl/tests/smoke.rs
@@ -4,7 +4,7 @@
 // The FFT round-trip tests (and their complex types) do not run on
 // aarch64-unknown-linux-gnu, where FFT returns Unsupported.
 #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
-use nuvai_mkl::fft::{MKL_Complex16, MKL_Complex8};
+use nuvai_mkl::fft::{MKL_Complex8, MKL_Complex16};
 use nuvai_mkl::layout::{Layout, Transpose};
 use nuvai_mkl::{blas, dss, fft, lapack, pardiso, vml, vsl};
 
@@ -67,60 +67,69 @@ fn blas_rejects_undersized_slices() {
     let a = [1.0f32; 4];
     let b = [1.0f32; 4];
     let mut c = [0.0f32; 4];
-    assert!(blas::sgemm(
-        Layout::RowMajor,
-        Transpose::NoTrans,
-        Transpose::NoTrans,
-        100_000,
-        2,
-        2,
-        1.0,
-        &a,
-        2,
-        &b,
-        2,
-        0.0,
-        &mut c,
-        2,
-    )
-    .is_err());
+    assert!(
+        blas::sgemm(
+            Layout::RowMajor,
+            Transpose::NoTrans,
+            Transpose::NoTrans,
+            100_000,
+            2,
+            2,
+            1.0,
+            &a,
+            2,
+            &b,
+            2,
+            0.0,
+            &mut c,
+            2,
+        )
+        .is_err()
+    );
 
     // Leading dimension below the stored width (row-major `lda < k`).
     let a = [1.0f32; 4];
     let b = [1.0f32; 4];
     let mut c = [0.0f32; 4];
-    assert!(blas::sgemm(
-        Layout::RowMajor,
-        Transpose::NoTrans,
-        Transpose::NoTrans,
-        2,
-        2,
-        2,
-        1.0,
-        &a,
-        1,
-        &b,
-        2,
-        0.0,
-        &mut c,
-        2,
-    )
-    .is_err());
+    assert!(
+        blas::sgemm(
+            Layout::RowMajor,
+            Transpose::NoTrans,
+            Transpose::NoTrans,
+            2,
+            2,
+            2,
+            1.0,
+            &a,
+            1,
+            &b,
+            2,
+            0.0,
+            &mut c,
+            2,
+        )
+        .is_err()
+    );
 
-    // Level-1: undersized, zero stride, and negative count are all invalid.
+    // Level-1: undersized, zero/negative stride, and negative count are all
+    // invalid. A negative stride is rejected up front — the wrapper passes the
+    // slice's first element as the CBLAS base, so a negative stride would walk
+    // *below* the slice (heap OOB from safe code).
     let x = [1.0f32; 2];
     let mut y = [0.0f32; 2];
     assert!(blas::saxpy(3, 1.0, &x, 1, &mut y, 1).is_err());
     assert!(blas::saxpy(3, 1.0, &x, 0, &mut y, 1).is_err());
+    assert!(blas::saxpy(3, 1.0, &x, -1, &mut y, 1).is_err());
     assert!(blas::saxpy(-1, 1.0, &x, 1, &mut y, 1).is_err());
 
     // `sdot`/`ddot` now return `Result`.
     assert!(blas::sdot(3, &x, 1, &[1.0f32; 2], 1).is_err());
     assert!(blas::ddot(3, &[1.0f64; 2], 1, &[1.0f64; 2], 1).is_err());
 
-    // `sscal`/`dscal` undersized.
+    // `sscal`/`dscal` undersized or negative stride.
     let mut xs = [1.0f32; 2];
     assert!(blas::sscal(3, 2.0, &mut xs, 1).is_err());
+    assert!(blas::sscal(3, 2.0, &mut xs, -1).is_err());
     let mut xd = [1.0f64; 2];
     assert!(blas::dscal(3, 2.0, &mut xd, 1).is_err());
 }
@@ -171,12 +180,27 @@ fn fft_roundtrip_c32() {
     let plan = fft::FftPlan::new_c32(4).unwrap();
     // Impulse δ = [1,0,0,0] -> forward = [1,1,1,1].
     let input = [
-        MKL_Complex8 { real: 1.0, imag: 0.0 },
-        MKL_Complex8 { real: 0.0, imag: 0.0 },
-        MKL_Complex8 { real: 0.0, imag: 0.0 },
-        MKL_Complex8 { real: 0.0, imag: 0.0 },
+        MKL_Complex8 {
+            real: 1.0,
+            imag: 0.0,
+        },
+        MKL_Complex8 {
+            real: 0.0,
+            imag: 0.0,
+        },
+        MKL_Complex8 {
+            real: 0.0,
+            imag: 0.0,
+        },
+        MKL_Complex8 {
+            real: 0.0,
+            imag: 0.0,
+        },
     ];
-    let mut freq = [MKL_Complex8 { real: 0.0, imag: 0.0 }; 4];
+    let mut freq = [MKL_Complex8 {
+        real: 0.0,
+        imag: 0.0,
+    }; 4];
     plan.forward_c32(&input, &mut freq).unwrap();
     for f in &freq {
         assert!((f.real - 1.0).abs() <= 1e-5, "real = {}", f.real);
@@ -184,9 +208,16 @@ fn fft_roundtrip_c32() {
     }
 
     // Backward of [1,1,1,1] recovers the impulse (default 1/n scaling).
-    let mut out = [MKL_Complex8 { real: 0.0, imag: 0.0 }; 4];
+    let mut out = [MKL_Complex8 {
+        real: 0.0,
+        imag: 0.0,
+    }; 4];
     plan.backward_c32(&freq, &mut out).unwrap();
-    assert!((out[0].real - 1.0).abs() <= 1e-5, "out[0] = {}", out[0].real);
+    assert!(
+        (out[0].real - 1.0).abs() <= 1e-5,
+        "out[0] = {}",
+        out[0].real
+    );
     for o in &out[1..] {
         assert!(o.real.abs() <= 1e-5 && o.imag.abs() <= 1e-5);
     }
@@ -198,21 +229,43 @@ fn fft_roundtrip_c64() {
     let plan = fft::FftPlan::new_c64(4).unwrap();
     // Same impulse test as the c32 variant, in double precision.
     let input = [
-        MKL_Complex16 { real: 1.0, imag: 0.0 },
-        MKL_Complex16 { real: 0.0, imag: 0.0 },
-        MKL_Complex16 { real: 0.0, imag: 0.0 },
-        MKL_Complex16 { real: 0.0, imag: 0.0 },
+        MKL_Complex16 {
+            real: 1.0,
+            imag: 0.0,
+        },
+        MKL_Complex16 {
+            real: 0.0,
+            imag: 0.0,
+        },
+        MKL_Complex16 {
+            real: 0.0,
+            imag: 0.0,
+        },
+        MKL_Complex16 {
+            real: 0.0,
+            imag: 0.0,
+        },
     ];
-    let mut freq = [MKL_Complex16 { real: 0.0, imag: 0.0 }; 4];
+    let mut freq = [MKL_Complex16 {
+        real: 0.0,
+        imag: 0.0,
+    }; 4];
     plan.forward_c64(&input, &mut freq).unwrap();
     for f in &freq {
         assert!((f.real - 1.0).abs() <= 1e-9, "real = {}", f.real);
         assert!(f.imag.abs() <= 1e-9, "imag = {}", f.imag);
     }
 
-    let mut out = [MKL_Complex16 { real: 0.0, imag: 0.0 }; 4];
+    let mut out = [MKL_Complex16 {
+        real: 0.0,
+        imag: 0.0,
+    }; 4];
     plan.backward_c64(&freq, &mut out).unwrap();
-    assert!((out[0].real - 1.0).abs() <= 1e-9, "out[0] = {}", out[0].real);
+    assert!(
+        (out[0].real - 1.0).abs() <= 1e-9,
+        "out[0] = {}",
+        out[0].real
+    );
     for o in &out[1..] {
         assert!(o.real.abs() <= 1e-9 && o.imag.abs() <= 1e-9);
     }
@@ -226,19 +279,35 @@ fn fft_roundtrip_c32_len2() {
     // and its inverse recovers it.
     let plan = fft::FftPlan::new_c32(2).unwrap();
     let input = [
-        MKL_Complex8 { real: 1.0, imag: 0.0 },
-        MKL_Complex8 { real: 0.0, imag: 0.0 },
+        MKL_Complex8 {
+            real: 1.0,
+            imag: 0.0,
+        },
+        MKL_Complex8 {
+            real: 0.0,
+            imag: 0.0,
+        },
     ];
-    let mut freq = [MKL_Complex8 { real: 0.0, imag: 0.0 }; 2];
+    let mut freq = [MKL_Complex8 {
+        real: 0.0,
+        imag: 0.0,
+    }; 2];
     plan.forward_c32(&input, &mut freq).unwrap();
     for f in &freq {
         assert!((f.real - 1.0).abs() <= 1e-5, "real = {}", f.real);
         assert!(f.imag.abs() <= 1e-5, "imag = {}", f.imag);
     }
 
-    let mut out = [MKL_Complex8 { real: 0.0, imag: 0.0 }; 2];
+    let mut out = [MKL_Complex8 {
+        real: 0.0,
+        imag: 0.0,
+    }; 2];
     plan.backward_c32(&freq, &mut out).unwrap();
-    assert!((out[0].real - 1.0).abs() <= 1e-5, "out[0] = {}", out[0].real);
+    assert!(
+        (out[0].real - 1.0).abs() <= 1e-5,
+        "out[0] = {}",
+        out[0].real
+    );
     for o in &out[1..] {
         assert!(o.real.abs() <= 1e-5 && o.imag.abs() <= 1e-5);
     }
@@ -250,19 +319,35 @@ fn fft_roundtrip_c64_len2() {
     // Double-precision analogue of `fft_roundtrip_c32_len2`.
     let plan = fft::FftPlan::new_c64(2).unwrap();
     let input = [
-        MKL_Complex16 { real: 1.0, imag: 0.0 },
-        MKL_Complex16 { real: 0.0, imag: 0.0 },
+        MKL_Complex16 {
+            real: 1.0,
+            imag: 0.0,
+        },
+        MKL_Complex16 {
+            real: 0.0,
+            imag: 0.0,
+        },
     ];
-    let mut freq = [MKL_Complex16 { real: 0.0, imag: 0.0 }; 2];
+    let mut freq = [MKL_Complex16 {
+        real: 0.0,
+        imag: 0.0,
+    }; 2];
     plan.forward_c64(&input, &mut freq).unwrap();
     for f in &freq {
         assert!((f.real - 1.0).abs() <= 1e-9, "real = {}", f.real);
         assert!(f.imag.abs() <= 1e-9, "imag = {}", f.imag);
     }
 
-    let mut out = [MKL_Complex16 { real: 0.0, imag: 0.0 }; 2];
+    let mut out = [MKL_Complex16 {
+        real: 0.0,
+        imag: 0.0,
+    }; 2];
     plan.backward_c64(&freq, &mut out).unwrap();
-    assert!((out[0].real - 1.0).abs() <= 1e-9, "out[0] = {}", out[0].real);
+    assert!(
+        (out[0].real - 1.0).abs() <= 1e-9,
+        "out[0] = {}",
+        out[0].real
+    );
     for o in &out[1..] {
         assert!(o.real.abs() <= 1e-9 && o.imag.abs() <= 1e-9);
     }
@@ -275,18 +360,40 @@ fn fft_roundtrip_c32_non_pow2() {
     // path (DFTI on Intel; vDSP's interleaved `f·2^n` family on aarch64). As for
     // any length, the DFT of the impulse is all-ones and its inverse recovers it.
     let plan = fft::FftPlan::new_c32(24).unwrap();
-    let mut input = vec![MKL_Complex8 { real: 0.0, imag: 0.0 }; 24];
+    let mut input = vec![
+        MKL_Complex8 {
+            real: 0.0,
+            imag: 0.0
+        };
+        24
+    ];
     input[0].real = 1.0;
-    let mut freq = vec![MKL_Complex8 { real: 0.0, imag: 0.0 }; 24];
+    let mut freq = vec![
+        MKL_Complex8 {
+            real: 0.0,
+            imag: 0.0
+        };
+        24
+    ];
     plan.forward_c32(&input, &mut freq).unwrap();
     for f in &freq {
         assert!((f.real - 1.0).abs() <= 1e-5, "real = {}", f.real);
         assert!(f.imag.abs() <= 1e-5, "imag = {}", f.imag);
     }
 
-    let mut out = vec![MKL_Complex8 { real: 0.0, imag: 0.0 }; 24];
+    let mut out = vec![
+        MKL_Complex8 {
+            real: 0.0,
+            imag: 0.0
+        };
+        24
+    ];
     plan.backward_c32(&freq, &mut out).unwrap();
-    assert!((out[0].real - 1.0).abs() <= 1e-5, "out[0] = {}", out[0].real);
+    assert!(
+        (out[0].real - 1.0).abs() <= 1e-5,
+        "out[0] = {}",
+        out[0].real
+    );
     for o in &out[1..] {
         assert!(o.real.abs() <= 1e-5 && o.imag.abs() <= 1e-5);
     }
@@ -299,18 +406,40 @@ fn fft_roundtrip_c32_len8() {
     // (macOS 12.0+ on aarch64; DFTI on Intel), so this exercises that path
     // directly rather than the split-complex fallback used for lengths 2 and 4.
     let plan = fft::FftPlan::new_c32(8).unwrap();
-    let mut input = vec![MKL_Complex8 { real: 0.0, imag: 0.0 }; 8];
+    let mut input = vec![
+        MKL_Complex8 {
+            real: 0.0,
+            imag: 0.0
+        };
+        8
+    ];
     input[0].real = 1.0;
-    let mut freq = vec![MKL_Complex8 { real: 0.0, imag: 0.0 }; 8];
+    let mut freq = vec![
+        MKL_Complex8 {
+            real: 0.0,
+            imag: 0.0
+        };
+        8
+    ];
     plan.forward_c32(&input, &mut freq).unwrap();
     for f in &freq {
         assert!((f.real - 1.0).abs() <= 1e-5, "real = {}", f.real);
         assert!(f.imag.abs() <= 1e-5, "imag = {}", f.imag);
     }
 
-    let mut out = vec![MKL_Complex8 { real: 0.0, imag: 0.0 }; 8];
+    let mut out = vec![
+        MKL_Complex8 {
+            real: 0.0,
+            imag: 0.0
+        };
+        8
+    ];
     plan.backward_c32(&freq, &mut out).unwrap();
-    assert!((out[0].real - 1.0).abs() <= 1e-5, "out[0] = {}", out[0].real);
+    assert!(
+        (out[0].real - 1.0).abs() <= 1e-5,
+        "out[0] = {}",
+        out[0].real
+    );
     for o in &out[1..] {
         assert!(o.real.abs() <= 1e-5 && o.imag.abs() <= 1e-5);
     }
@@ -321,18 +450,40 @@ fn fft_roundtrip_c32_len8() {
 fn fft_roundtrip_c64_len8() {
     // Double-precision analogue of `fft_roundtrip_c32_len8`.
     let plan = fft::FftPlan::new_c64(8).unwrap();
-    let mut input = vec![MKL_Complex16 { real: 0.0, imag: 0.0 }; 8];
+    let mut input = vec![
+        MKL_Complex16 {
+            real: 0.0,
+            imag: 0.0
+        };
+        8
+    ];
     input[0].real = 1.0;
-    let mut freq = vec![MKL_Complex16 { real: 0.0, imag: 0.0 }; 8];
+    let mut freq = vec![
+        MKL_Complex16 {
+            real: 0.0,
+            imag: 0.0
+        };
+        8
+    ];
     plan.forward_c64(&input, &mut freq).unwrap();
     for f in &freq {
         assert!((f.real - 1.0).abs() <= 1e-9, "real = {}", f.real);
         assert!(f.imag.abs() <= 1e-9, "imag = {}", f.imag);
     }
 
-    let mut out = vec![MKL_Complex16 { real: 0.0, imag: 0.0 }; 8];
+    let mut out = vec![
+        MKL_Complex16 {
+            real: 0.0,
+            imag: 0.0
+        };
+        8
+    ];
     plan.backward_c64(&freq, &mut out).unwrap();
-    assert!((out[0].real - 1.0).abs() <= 1e-9, "out[0] = {}", out[0].real);
+    assert!(
+        (out[0].real - 1.0).abs() <= 1e-9,
+        "out[0] = {}",
+        out[0].real
+    );
     for o in &out[1..] {
         assert!(o.real.abs() <= 1e-9 && o.imag.abs() <= 1e-9);
     }


### PR DESCRIPTION
## Summary

Closes #20 — the 8 BLAS pass-throughs (`sgemm`..`dscal`) forwarded raw pointers to CBLAS with zero validation, so an undersized slice (e.g. `sgemm` with `m=100000` and a 4-element `a`) was a heap out-of-bounds read/write reachable from safe code.

Mirrors `lapack::check_*_dims` with validators wired into every routine:

- `check_gemm_dims` — `m/n/k ≥ 0`, plus per-operand leading-dimension and slice-length checks against the BLAS sizing convention (layout- and transpose-adjusted trailing-element bounds).
- `check_vector` — `n ≥ 0`, non-zero stride, `1 + (n−1)·|inc|` minimum length.

`sdot`/`ddot` now return `Result<f32>`/`Result<f64>` so they can report an invalid slice (previously `f32`/`f64`).

## Tests

- New `blas_rejects_undersized_slices` regression test covering the exact UB shape from #20, a bad `lda`, and undersized / zero-stride / negative-count vectors.
- `cargo test -p nuvai-mkl` → 27 passed. `cargo clippy -p nuvai-mkl --tests` clean.

## Notes

- Partially addresses #38 (the `Result<()>` on the gemm/axpy/scal paths is no longer vestigial — it now has a real `Err` arm).