### PR TITLE
fix(dss): validate rhs.len() against factored n (heap OOB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,13 @@ the crate is pre-1.0, so breaking changes are permitted without a major bump.
   previously accepted but walked *below* the slice (the wrapper passes the
   slice's first element as the CBLAS base), making heap out-of-bounds
   reads/writes reachable from safe code.
+
+- `Dss::solve` validates `rhs.len()` against the factored dimension `n` on
+  every backend (issue #21). The Intel arm sized the solution buffer to
+  `rhs.len()` while `dss_solve_real_` writes `n` elements, so an undersized
+  RHS was a heap out-of-bounds write reachable from safe code and an oversized
+  one returned a `Vec` padded past the values actually solved for. `n` is now
+  captured at factor time (the Intel DSS handle is opaque, so it cannot be
+  recovered at solve time) and the check runs ahead of the `cfg` dispatch
+  rather than only on the aarch64 arm. A mismatched length now returns
+  `ErrorKind::InvalidArgument`.

--- a/crates/nuvai-mkl/src/dss.rs
+++ b/crates/nuvai-mkl/src/dss.rs
@@ -43,11 +43,16 @@ type DssHandle = nuvai_mkl_sys::SparseOpaqueFactorization_Double;
 type DssHandle = ();
 
 /// A factorized DSS handle (double precision, real symmetric).
-// On `aarch64-unknown-linux-gnu` no `Dss` can be constructed, so the `handle`
-// field is never read there.
+// On `aarch64-unknown-linux-gnu` no `Dss` can be constructed, so the fields are
+// never read there.
 #[cfg_attr(all(target_os = "linux", target_arch = "aarch64"), allow(dead_code))]
 pub struct Dss {
     handle: DssHandle,
+    /// Factored dimension (row/column count), captured at factor time. The
+    /// solve writes exactly `n` elements, so it is the only valid `rhs` length.
+    /// On Intel the handle is an opaque `*mut c_void` from which `n` cannot be
+    /// recovered later, so it must be stored here.
+    n: i32,
 }
 
 impl Dss {
@@ -106,7 +111,10 @@ impl Dss {
                 unsafe { nuvai_mkl_sys::_SparseDestroyOpaqueNumeric_Double(&mut factor) };
                 return Err(Error::mkl(status, "_SparseFactorSymmetric_Double"));
             }
-            Ok(Self { handle: factor })
+            Ok(Self {
+                handle: factor,
+                n: n_rows,
+            })
         }
         #[cfg(not(target_arch = "aarch64"))]
         {
@@ -167,35 +175,44 @@ impl Dss {
                 }
             }
 
-            Ok(Self { handle })
+            Ok(Self { handle, n: n_rows })
         }
     }
 
     /// Solve for a single right-hand side; returns the solution.
+    ///
+    /// `rhs` must hold exactly `n` values, where `n` is the dimension of the
+    /// factored matrix; any other length is
+    /// [`ErrorKind::InvalidArgument`](crate::error::ErrorKind::InvalidArgument).
     pub fn solve(&self, rhs: &[f64]) -> Result<Vec<f64>> {
+        // Validated ahead of the `cfg` dispatch so every backend enforces it
+        // identically: the solve writes exactly `self.n` values regardless of
+        // `rhs.len()`, so a short `rhs` would size the output buffer below what
+        // the backend writes (heap out-of-bounds write reachable from safe
+        // code), and a long one would silently solve against a prefix while
+        // returning a `Vec` sized to the caller's misleading length.
+        if rhs.len() != self.n as usize {
+            return Err(Error::invalid("DSS: rhs length mismatch"));
+        }
         #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
         {
             // No DSS backend on aarch64-unknown-linux-gnu.
-            let _ = rhs;
             Err(Error::unsupported_linux_aarch64("DSS"))
         }
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
-            let n = self.handle.symbolicFactorization.rowCount;
-            if rhs.len() != n as usize {
-                return Err(Error::invalid("DSS: rhs length mismatch"));
-            }
-            crate::pardiso::solve_with_factor(&self.handle, n, rhs)
+            crate::pardiso::solve_with_factor(&self.handle, self.n, rhs)
         }
         #[cfg(not(target_arch = "aarch64"))]
         {
             let n_rhs = 1i32;
             let opt_solve = 0i32; // normal (non-transpose, non-conjugate) solve
-            let mut sol = vec![0.0f64; rhs.len()];
+            let mut sol = vec![0.0f64; self.n as usize];
             let mut handle = self.handle; // local copy: DSS takes the handle by address
-            // SAFETY: `handle` is a valid factorized DSS handle; `rhs` and `sol`
-            // are valid slices and `sol` is sized to `rhs.len()` (single RHS of
-            // `n` values), so the solve reads/writes within bounds.
+            // SAFETY: `handle` is a valid factorized DSS handle; `sol` is sized
+            // to the same factored `n` that `dss_solve_real_` writes, and `rhs`
+            // holds exactly `n` readable values (checked above), so the solve
+            // reads/writes within bounds.
             let status = unsafe {
                 nuvai_mkl_sys::dss_solve_real_(
                     &mut handle,

--- a/crates/nuvai-mkl/tests/smoke.rs
+++ b/crates/nuvai-mkl/tests/smoke.rs
@@ -656,6 +656,44 @@ fn dss_solve_2x2() {
 
 #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
 #[test]
+fn dss_solve_rejects_rhs_length_mismatch() {
+    // #21: the backend writes exactly `n` values into the solution buffer
+    // regardless of `rhs.len()`. Pre-fix the Intel arm sized that buffer to
+    // `rhs.len()`, so an undersized RHS drove a heap out-of-bounds *write*
+    // reachable from safe code, and an oversized one returned a `Vec` padded
+    // past the `n` values actually solved for.
+    //
+    // Same SPD matrix as `dss_solve_2x2`: A = [[4,1],[1,3]], so n == 2.
+    let row_index = [0i32, 2, 3];
+    let columns = [0i32, 1, 1];
+    let values = [4.0f64, 1.0, 3.0];
+    let dss = dss::Dss::factor_symmetric(&row_index, &columns, &values).unwrap();
+
+    // `InvalidArgument` specifically, not merely `is_err()`: it proves the
+    // safe-Rust guard rejected the call before any pointer reached the backend.
+    // A corrupting call that happened to return a non-zero MKL status would
+    // satisfy `is_err()` while the UB still occurred.
+    use nuvai_mkl::error::ErrorKind;
+
+    // Undersized: pre-fix this sized `sol` to 1 while DSS wrote 2.
+    let err = dss.solve(&[5.0f64]).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+
+    // Oversized: only the first 2 values are ever solved for.
+    let err = dss.solve(&[5.0f64, 4.0, 9.0]).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+
+    // Empty.
+    let err = dss.solve(&[]).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+
+    // The valid-length path still solves correctly.
+    let x = dss.solve(&[5.0f64, 4.0]).unwrap();
+    assert_close64(&x, &[1.0, 1.0], 1e-9);
+}
+
+#[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
+#[test]
 fn vsl_uniform_rejects_empty_range() {
     let stream = vsl::Stream::new(7).unwrap();
     // Empty (a == b), inverted (a > b), and NaN ranges must error, not panic:


### PR DESCRIPTION
Closes #21 · Epic #19 · P1 · `depth:baseline`

## Problem

The Intel arm of `Dss::solve` (`#[cfg(not(target_arch = "aarch64"))]`) sized the
solution buffer to `rhs.len()`:

```rust
let mut sol = vec![0.0f64; rhs.len()];
```

but `dss_solve_real_` writes `n` — the *factored* dimension — elements. So:

- **undersized RHS** (`rhs.len() < n`) → heap **out-of-bounds write**, reachable from safe code
- **oversized RHS** (`rhs.len() > n`) → the returned `Vec` is padded past the values actually solved for

The `aarch64-apple-darwin` arm already validated the length via
`handle.symbolicFactorization.rowCount`. On Intel the handle is an opaque
`*mut c_void`, so `n` cannot be recovered at solve time and must be captured at
factor time.

## Fix

- add `n: i32` to `Dss`, populated from the already-validated `n_rows` in **both**
  constructing arms of `factor_symmetric`
- hoist the `rhs.len() != n` check **above** the `cfg` dispatch, so all three targets
  enforce it through one code path; drop the now-redundant aarch64-local check
- size the Intel `sol` buffer from `self.n`, not the caller's length, so the buffer is
  correct independently of the guard
- correct the Intel `// SAFETY:` comment, which claimed `sol` was sized to `rhs.len()`
  as though that equalled `n`

A mismatched length now returns `ErrorKind::InvalidArgument`.

## Tests

New `dss_solve_rejects_rhs_length_mismatch` in `tests/smoke.rs` asserts
`ErrorKind::InvalidArgument` specifically — not merely `is_err()` — for undersized,
oversized, and empty RHS, then confirms the valid-length path still solves. Asserting
the kind proves the safe-Rust guard fired *before* any pointer reached the backend; a
corrupting call that happened to return a non-zero MKL status would satisfy `is_err()`
while the UB still occurred.

## Verification

The local dev host is `aarch64-apple-darwin`, which takes the arm that was **already
correct** — so local green means nothing here. Validated on the remote
`x86_64-unknown-linux-gnu` build VM, the only target that compiles the affected arm:

| Stage | Result |
|---|---|
| `cargo check -p nuvai-mkl` | pass |
| `cargo build -p nuvai-mkl` | pass |
| `cargo test --workspace` | pass — smoke 21/21, incl. `dss_solve_rejects_rhs_length_mismatch` and `dss_solve_2x2` |
| `dead_code` on new `Dss` field | none |

## ⚠️ CI caveat — pre-existing, not from this PR

`cargo clippy --workspace --all-targets -- -D warnings` **fails on x86_64 on a clean
tree**, for two lints this change does not touch:

- `clippy::type_complexity` — `crates/nuvai-mkl-src/src/acquire.rs:185`
- `dead_code` — `crates/nuvai-mkl/src/error.rs:47` (`Error::unsupported` is only
  constructed in macos-aarch64 arms, so it is dead on Intel)

Neither fires on the aarch64 dev host, which is why they went unnoticed. Being fixed
separately — please don't chase them here.

Separately, `cargo test` on the x86_64 VM currently aborts at load with
`undefined symbol: omp_in_parallel` because the wrapper's mold linker config drops the
`-Wl,--no-as-needed,-liomp5` force-links from `build.rs`; the run above used an
`LD_PRELOAD` workaround. Also pre-existing infra, tracked separately.