### PR TITLE
chore(lint): fix x86_64 clippy -D warnings failures

### DIFF
--- a/crates/nuvai-mkl-src/src/acquire.rs
+++ b/crates/nuvai-mkl-src/src/acquire.rs
@@ -177,17 +177,22 @@ fn system_mkl() -> Option<MklInfo> {
     Some(MklInfo { include_dir, lib_dir, omp_lib_dir: None, dll_dirs })
 }
 
+/// One downloadable conda package: `(filename, sha256)`.
+#[cfg(not(target_arch = "aarch64"))]
+type Pkg<'a> = (&'a str, &'a str);
+
+/// The package set for one platform: base MKL, headers, an optional `devel`
+/// package (Windows import libs), and the runtime packages.
+#[cfg(not(target_arch = "aarch64"))]
+type PkgSet<'a> = (Pkg<'a>, Pkg<'a>, Option<Pkg<'a>>, &'a [Pkg<'a>]);
+
 /// Download + extract MKL into the shared cache, returning its paths.
 #[cfg(not(target_arch = "aarch64"))]
 fn download_mkl() -> MklInfo {
     let pkg_dir = cache_dir().join(format!("mkl-{MKL_VERSION}"));
 
-    let ((mkl_file, mkl_sha), (include_file, include_sha), devel, runtime): (
-        (&str, &str),
-        (&str, &str),
-        Option<(&str, &str)>,
-        &[(&str, &str)],
-    ) = match (cfg!(target_os = "linux"), cfg!(target_os = "windows")) {
+    let ((mkl_file, mkl_sha), (include_file, include_sha), devel, runtime): PkgSet<'_> =
+        match (cfg!(target_os = "linux"), cfg!(target_os = "windows")) {
         (true, _) => (
             (LINUX_MKL, LINUX_MKL_SHA256),
             (LINUX_INCLUDE, LINUX_INCLUDE_SHA256),

--- a/crates/nuvai-mkl/src/error.rs
+++ b/crates/nuvai-mkl/src/error.rs
@@ -44,6 +44,12 @@ impl Error {
     }
 
     /// An operation not available on this backend.
+    // Every caller sits behind `target_arch = "aarch64"`: the Accelerate arms of
+    // `fft`/`pardiso` on macOS, and `unsupported_linux_aarch64` on
+    // aarch64-unknown-linux-gnu. On Intel every domain has a real MKL backend,
+    // so nothing constructs this and it is dead there — not on the aarch64
+    // targets, so the `allow` stays scoped to the arch that needs it.
+    #[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
     pub(crate) fn unsupported(message: impl Into<String>) -> Self {
         Self {
             kind: ErrorKind::Unsupported,


### PR DESCRIPTION
Closes #42

## Problem

`cargo clippy --workspace --all-targets -- -D warnings` failed on a **clean tree** on
`x86_64-unknown-linux-gnu`. Neither lint fires on the `aarch64-apple-darwin` dev host —
both sit in `cfg`-gated code that only the Intel target compiles, which is why they went
unnoticed. Surfaced during remote validation of #21 (PR #41).

The practical cost: the workspace clippy gate was red on Intel for *every* PR, which
trains reviewers to ignore a failing check — the failure mode that lets a real lint
through later.

## Changes

**`crates/nuvai-mkl-src/src/acquire.rs`** — `clippy::type_complexity`

`download_mkl`'s package table carried a four-line inline tuple annotation. Extracted:

```rust
type Pkg<'a> = (&'a str, &'a str);
type PkgSet<'a> = (Pkg<'a>, Pkg<'a>, Option<Pkg<'a>>, &'a [Pkg<'a>]);
```

Deliberately lifetime-*parameterized* rather than `&'static`: the match arms build
`&[(A, B)][..]` slice literals that depend on rvalue static promotion, and keeping the
lifetime inferred means inference is identical to the inline annotation. This is a purely
syntactic refactor.

**`crates/nuvai-mkl/src/error.rs`** — `dead_code`

`Error::unsupported` is constructed only behind `target_arch = "aarch64"`: the Accelerate
arms of `fft`/`pardiso` on macOS, and `unsupported_linux_aarch64` on
`aarch64-unknown-linux-gnu`. On Intel every domain has a real MKL backend, so nothing
constructs it. Scoped the `allow(dead_code)` to exactly that arch via `cfg_attr` rather
than suppressing it unconditionally.

No functional change.

## Verification

Both edits live in code the aarch64 dev host does **not** compile, so local green proves
nothing — `download_mkl` in particular had never been type-checked anywhere. Validated on
the remote `x86_64-unknown-linux-gnu` VM:

| Stage | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | **exit 0, zero diagnostics** ← acceptance criterion |
| `cargo check --workspace` | pass |
| `cargo build --workspace` | pass |
| `cargo test --workspace` | pass — smoke 20/20, unit 2/2 |
| new warnings introduced | none |

Also confirmed still clean on `aarch64-apple-darwin`.

> Note: `cargo test` on that VM requires an `LD_PRELOAD` workaround for a pre-existing
> infra issue (mold drops `build.rs`'s `--no-as-needed` force-links, so MKL's threading
> layer can't resolve `omp_*`). Unrelated to this PR; tracked separately.