### PR TITLE
fix(backend): compile_error! when both accelerate+openblas enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ the crate is pre-1.0, so breaking changes are permitted without a major bump.
 
 ### Fixed
 
+- `nuvai-mkl-src` now fails loudly when both the `accelerate` and `openblas`
+  backend features are enabled on `aarch64-apple-darwin` instead of silently
+  resolving to OpenBLAS (issue #35). Enabling both features is as ambiguous as
+  enabling neither: the selection now triggers a `compile_error!` at library
+  compile time and an `Err` from `backend_for_target` at build-script time (the
+  host-compiled path used when cross-compiling, where the library
+  `compile_error!` cannot fire), matching ADR-0003 "selection is explicit,
+  never silent".
+
 - `blas` level-1 routines reject negative strides. A negative stride was
   previously accepted but walked *below* the slice (the wrapper passes the
   slice's first element as the CBLAS base), making heap out-of-bounds

--- a/crates/nuvai-mkl-src/src/backend.rs
+++ b/crates/nuvai-mkl-src/src/backend.rs
@@ -224,5 +224,26 @@ mod tests {
         assert!(backend_for_target("linux", "aarch64", Some("android")).is_err());
         assert!(backend_for_target("windows", "aarch64", Some("msvc")).is_err());
         assert!(backend_for_target("macos", "x86_64", None).is_err());
+        // The both-features case is rejected on aarch64-apple-darwin (the Err
+        // arm added for #35); guarded like the dedicated regression test below
+        // so it is a no-op where the crate cannot compile with both features.
+        if cfg!(feature = "accelerate") && cfg!(feature = "openblas") {
+            assert!(backend_for_target("macos", "aarch64", None).is_err());
+        }
+    }
+
+    #[test]
+    fn backend_for_target_rejects_both_features_on_macos_aarch64() {
+        use super::backend_for_target;
+
+        // With BOTH `accelerate` and `openblas` enabled the
+        // aarch64-apple-darwin selection must fail explicitly (ADR-0003)
+        // rather than silently prefer OpenBLAS. Guarded on the both-features
+        // cfg: on an aarch64-apple-darwin host the library cannot even compile
+        // with both features (the new compile_error!), so this test only
+        // asserts where both features compile, e.g. the x86_64 Linux build VM.
+        if cfg!(feature = "accelerate") && cfg!(feature = "openblas") {
+            assert!(backend_for_target("macos", "aarch64", None).is_err());
+        }
     }
 }

--- a/crates/nuvai-mkl-src/src/backend.rs
+++ b/crates/nuvai-mkl-src/src/backend.rs
@@ -31,6 +31,22 @@ compile_error!(
      enable `accelerate` (default) or `openblas`"
 );
 
+// Enabling BOTH `accelerate` and `openblas` is equally ambiguous: the backend
+// would silently resolve to OpenBLAS (the `openblas` arm is checked first),
+// violating "selection is explicit, never silent" (ADR-0003) exactly as the
+// no-feature case does. Reject at compile time — exactly one feature must be
+// enabled on `aarch64-apple-darwin`.
+#[cfg(all(
+    target_os = "macos",
+    target_arch = "aarch64",
+    feature = "accelerate",
+    feature = "openblas"
+))]
+compile_error!(
+    "nuvai-mkl-src: aarch64-apple-darwin requires exactly one backend feature — \
+     `accelerate` and `openblas` are mutually exclusive; enable exactly one"
+);
+
 // `x86_64-apple-darwin` is unsupported: Intel ended oneMKL for macOS after the
 // 2023.2.0 release (well short of the 2026.1.0 this crate links), so no
 // supported acquisition path exists. Reject at compile time rather than
@@ -78,10 +94,11 @@ pub enum Backend {
 ///
 /// On `aarch64-apple-darwin` the `openblas` feature selects OpenBLAS; the
 /// `accelerate` feature (default) selects Accelerate. Exactly one of the two
-/// must be enabled — a `compile_error!` above rejects the no-feature case. On
-/// `aarch64-unknown-linux-gnu` OpenBLAS is the only backend (no vDSP/vForce/
-/// Sparse exists on Linux) and both features are inert. On every other target
-/// Intel MKL is used and the feature flags are ignored.
+/// must be enabled — `compile_error!`s above reject both the no-feature and
+/// both-features cases. On `aarch64-unknown-linux-gnu` OpenBLAS is the only
+/// backend (no vDSP/vForce/Sparse exists on Linux) and both features are
+/// inert. On every other target Intel MKL is used and the feature flags are
+/// ignored.
 ///
 /// This is the *library-time* selector: its `#[cfg(...)]` reflects the target
 /// the crate is compiled for. Build scripts (which compile for the *host*)
@@ -120,7 +137,8 @@ pub fn backend() -> Backend {
 /// the real *target* triple. Pass those here to select the target's backend.
 ///
 /// Mirrors [`backend`]'s `#[cfg]` selection and rejects the same unsupported
-/// targets with an `Err` (rather than a compile error, since the build script
+/// targets — plus the no-feature and both-features `aarch64-apple-darwin`
+/// cases — with an `Err` (rather than a compile error, since the build script
 /// is host-compiled and cannot `compile_error!` for the target).
 pub fn backend_for_target(
     target_os: &str,
@@ -128,6 +146,14 @@ pub fn backend_for_target(
     target_env: Option<&str>,
 ) -> Result<Backend, &'static str> {
     match (target_os, target_arch, target_env) {
+        // Build scripts compile for the *host*, so the library `compile_error!`
+        // above cannot fire when cross-compiling from a non-macOS-aarch64 host
+        // — this Err (which panics the build script call site) is the
+        // build-script-time equivalent of that guard.
+        ("macos", "aarch64", _) if cfg!(feature = "accelerate") && cfg!(feature = "openblas") => Err(
+            "nuvai-mkl-src: aarch64-apple-darwin requires exactly one backend feature — \
+             `accelerate` and `openblas` are mutually exclusive; enable exactly one",
+        ),
         ("macos", "aarch64", _) => Ok(if cfg!(feature = "openblas") {
             Backend::OpenBlas
         } else {


### PR DESCRIPTION
## Summary

Closes #35 (epic #19). `crates/nuvai-mkl-src/src/backend.rs` silently resolved to OpenBLAS when both the `accelerate` and `openblas` Cargo features were enabled on `aarch64-apple-darwin`, violating ADR-0003 "selection is explicit, never silent" — the neither-feature case had a `compile_error!` but the both-feature case did not.

## Changes

- `crates/nuvai-mkl-src/src/backend.rs`:
  - New `compile_error!` for the both-features cfg on `aarch64-apple-darwin` (mirrors the existing no-feature guard).
  - New guarded `Err` arm in `backend_for_target()` before the `("macos", "aarch64", _) => Ok` arm — the build-script entry point compiles for the *host* and cannot fire the library `compile_error!` when cross-compiling, so it now returns `Err` (panicking the build script) instead of silently linking OpenBLAS.
  - Regression test `backend_for_target_rejects_both_features_on_macos_aarch64` (gated on the both-features cfg; asserts for real on x86_64 where both features compile) + extended `backend_for_target_is_exhaustive`.
  - Doc comments updated to mention the both-features case.
- `CHANGELOG.md`: `### Fixed` entry referencing #35.

## Validation

- Local (aarch64-apple-darwin): default/openblas checks pass; neither-features and both-features builds fail with the expected `compile_error!`; `cargo test --workspace` 32 passed; clippy -D warnings clean; fmt clean.
- Remote x86_64 VM (`nuvai-mkl-x86_64`): `cargo test -p nuvai-mkl-src --features accelerate,openblas` → rc=0, 3 passed including the new regression test (LD_PRELOAD workaround for mold-linker issue #44).
