### PR TITLE
fix(build): emit macOS OpenBLAS link-search from build.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,9 @@ jobs:
     name: aarch64-apple-darwin (OpenBLAS)
     runs-on: macos-14-xlarge # public Apple Silicon runner (arm64)
     env:
-      # openblas is keg-only, so `-lopenblas` needs an explicit search path.
-      RUSTFLAGS: "-L /opt/homebrew/opt/openblas/lib"
-      # Same as the Accelerate job: vDSP's interleaved-complex DFT (task #13)
-      # is macOS 12.0+, so pin the deployment target for the linker.
+      # vDSP's interleaved-complex DFT (task #13) is macOS 12.0+, so pin the
+      # deployment target for the linker. No RUSTFLAGS: the keg-only OpenBLAS
+      # search path is emitted by nuvai-mkl-src's build.rs (`rustc-link-search`).
       MACOSX_DEPLOYMENT_TARGET: "12.0"
     steps:
       - uses: actions/checkout@v4

--- a/crates/nuvai-mkl-src/build.rs
+++ b/crates/nuvai-mkl-src/build.rs
@@ -24,6 +24,9 @@ fn main() {
     println!("cargo:rerun-if-changed=src/backend.rs");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_OPENBLAS");
     println!("cargo:rerun-if-env-changed=OPENBLAS_ROOT");
+    // The macOS `openblas` fallback probes the Homebrew keg's existence on disk,
+    // so re-run when it appears or disappears.
+    println!("cargo:rerun-if-changed=/opt/homebrew/opt/openblas/lib");
 
     // docs.rs has no network and no MKL; skip linking there.
     if std::env::var("DOCS_RS").is_ok() {
@@ -54,16 +57,20 @@ fn main() {
             if target_os == "macos" {
                 // Homebrew installs openblas keg-only, so `-lopenblas` needs an
                 // explicit search path. Prefer OPENBLAS_ROOT (conda/pip) and
-                // fall back to the Homebrew keg on Apple Silicon. This must be a
-                // `rustc-link-search` (not RUSTFLAGS `-L`) because Cargo does not
-                // forward RUSTFLAGS to build-script linking, and the `-lopenblas`
-                // above propagates to build scripts too.
-                let lib_dir = std::env::var("OPENBLAS_ROOT")
-                    .ok()
-                    .filter(|root| !root.trim().is_empty())
-                    .map(|root| format!("{root}/lib"))
-                    .unwrap_or_else(|| "/opt/homebrew/opt/openblas/lib".to_string());
-                println!("cargo:rustc-link-search=native={lib_dir}");
+                // fall back to the Homebrew keg on Apple Silicon — but only if
+                // the keg actually exists, so a MacPorts `/opt/local`, a
+                // `/usr/local`, or a manual-build install resolves via the default
+                // search path instead of being silently shadowed by a stale
+                // package-manager path. This must be a `rustc-link-search` (not
+                // RUSTFLAGS `-L`) because Cargo does not forward RUSTFLAGS to
+                // build-script linking, and the `-lopenblas` above propagates to
+                // build scripts too.
+                if let Some(lib_dir) = openblas_root_lib_dir().or_else(|| {
+                    let keg = "/opt/homebrew/opt/openblas/lib";
+                    std::path::Path::new(keg).is_dir().then(|| keg.to_string())
+                }) {
+                    println!("cargo:rustc-link-search=native={lib_dir}");
+                }
                 println!("cargo:rustc-link-lib=framework=Accelerate");
             }
             // Linux-aarch64: OpenBLAS is the only backend and covers only
@@ -77,10 +84,9 @@ fn main() {
             // emits the rpath instead.
             if target_os == "linux"
                 && target_arch == "aarch64"
-                && let Ok(root) = std::env::var("OPENBLAS_ROOT")
-                && !root.trim().is_empty()
+                && let Some(lib_dir) = openblas_root_lib_dir()
             {
-                println!("cargo:rustc-link-search=native={root}/lib");
+                println!("cargo:rustc-link-search=native={lib_dir}");
             }
         }
     }

--- a/crates/nuvai-mkl-src/build.rs
+++ b/crates/nuvai-mkl-src/build.rs
@@ -52,6 +52,18 @@ fn main() {
             // VML (vForce) and the sparse solvers (Sparse/SparseSolve) still
             // call Accelerate, so both must be linked on this path.
             if target_os == "macos" {
+                // Homebrew installs openblas keg-only, so `-lopenblas` needs an
+                // explicit search path. Prefer OPENBLAS_ROOT (conda/pip) and
+                // fall back to the Homebrew keg on Apple Silicon. This must be a
+                // `rustc-link-search` (not RUSTFLAGS `-L`) because Cargo does not
+                // forward RUSTFLAGS to build-script linking, and the `-lopenblas`
+                // above propagates to build scripts too.
+                let lib_dir = std::env::var("OPENBLAS_ROOT")
+                    .ok()
+                    .filter(|root| !root.trim().is_empty())
+                    .map(|root| format!("{root}/lib"))
+                    .unwrap_or_else(|| "/opt/homebrew/opt/openblas/lib".to_string());
+                println!("cargo:rustc-link-search=native={lib_dir}");
                 println!("cargo:rustc-link-lib=framework=Accelerate");
             }
             // Linux-aarch64: OpenBLAS is the only backend and covers only

--- a/crates/nuvai-mkl-src/src/backend.rs
+++ b/crates/nuvai-mkl-src/src/backend.rs
@@ -161,6 +161,24 @@ pub const fn backend_tag(backend: Backend) -> &'static str {
     }
 }
 
+/// Resolve the OpenBLAS `lib` directory from `OPENBLAS_ROOT`, if set.
+///
+/// `OPENBLAS_ROOT` is the explicit override for a non-default OpenBLAS install
+/// (conda/pip): a set, non-empty prefix contributes `{root}/lib` to the link
+/// search path (emitted by this crate's build script) and to the runtime rpath
+/// (emitted by `nuvai-mkl`'s build script, which owns the test/example
+/// binaries). Returns `None` when the variable is unset or empty, meaning
+/// "resolve `-lopenblas` via the toolchain's default search path". Selection is
+/// explicit, never silent (ADR-0003): this helper infers no package-manager-
+/// specific path — the macOS Homebrew-keg default is applied by the caller and
+/// gated on the keg's existence on disk.
+pub fn openblas_root_lib_dir() -> Option<String> {
+    std::env::var("OPENBLAS_ROOT")
+        .ok()
+        .filter(|root| !root.trim().is_empty())
+        .map(|root| format!("{root}/lib"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/nuvai-mkl/build.rs
+++ b/crates/nuvai-mkl/build.rs
@@ -14,6 +14,10 @@ fn main() {
         return;
     }
 
+    // The rpath arms below read OPENBLAS_ROOT; re-run when it changes so a
+    // cached build re-emits the correct rpath (and never keeps a stale one).
+    println!("cargo:rerun-if-env-changed=OPENBLAS_ROOT");
+
     // Build scripts compile for and run on the *host*, so `#[cfg(...)]` here
     // would describe the host, not the crate being built. Dispatch on the
     // target triple Cargo exposes as `CARGO_CFG_TARGET_*` instead (the same
@@ -40,6 +44,18 @@ fn main() {
             }
         }
         ("macos", "aarch64") => {
+            // An OpenBLAS in a non-default prefix (OPENBLAS_ROOT, e.g. conda/pip)
+            // carries an `@rpath/libopenblas.0.dylib` install name, so the loader
+            // needs an rpath at run time — mirror the linux-aarch64 arm.
+            // (Accelerate lives in the SDK and the Homebrew keg uses an absolute
+            // install name, so neither needs an rpath; the `openblas` feature
+            // guard keeps an Accelerate build from emitting a stray OpenBLAS
+            // rpath.)
+            if cfg!(feature = "openblas")
+                && let Some(lib_dir) = nuvai_mkl_src::openblas_root_lib_dir()
+            {
+                println!("cargo:rustc-link-arg=-Wl,-rpath,{lib_dir}");
+            }
             // The Accelerate interleaved vDSP DFT (`vDSP_DFT_Interleaved_*`) used
             // by the FFT backend is API_AVAILABLE(macos(12.0)); rustc defaults
             // the aarch64-apple-darwin deployment target to 11.0, which would


### PR DESCRIPTION
## Problem

The `aarch64-darwin-openblas` CI job (and any local `--no-default-features --features openblas` build on Apple Silicon) fails at the build-script link stage:

```
ld: library 'openblas' not found
```

## Root cause

`nuvai-mkl-src` declares `links = "mkl"`, so its `cargo:rustc-link-lib=dylib=openblas` directive propagates to every downstream link — including the build-script executables of `nuvai-mkl-sys` and `nuvai-mkl` (both depend on it via `[build-dependencies]`). On macOS the build script emitted no `cargo:rustc-link-search`, expecting CI's `RUSTFLAGS="-L /opt/homebrew/opt/openblas/lib"` to supply the path. But Cargo does **not** forward `RUSTFLAGS -L` to build-script linking, so `-lopenblas` had nowhere to resolve.

## Fix

- `crates/nuvai-mkl-src/build.rs`: emit `cargo:rustc-link-search=native=<dir>` on the macOS OpenBLAS path — honoring `OPENBLAS_ROOT`, defaulting to the Homebrew keg on Apple Silicon (`/opt/homebrew/opt/openblas/lib`).
- `.github/workflows/ci.yml`: drop the broken `RUSTFLAGS="-L …"` override from the `aarch64-darwin-openblas` job.

## Verification

On an Apple M3 Pro (arm64, aarch64-apple-darwin), with no env hacks:

- `cargo check --workspace --no-default-features --features openblas` ✅
- `cargo test --workspace --no-default-features --features openblas` ✅ 31 passed (28 smoke + 2 src + 1 sys)
- `cargo clippy --all-targets` ✅ clean; `cargo fmt --check` ✅
- Default Accelerate build unaffected ✅

## Notes

Independent of the GitHub Actions billing issue that currently blocks the two `macos-14-xlarge` runner jobs at allocation. Fixing billing alone would not have made this job green — it had a latent link-search bug as well.
